### PR TITLE
Adding option to re-enable customizer and menu items when FSE is enabled.

### DIFF
--- a/build/dlx-pw-preview.asset.php
+++ b/build/dlx-pw-preview.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react', 'wp-i18n', 'wp-plugins'), 'version' => '16a2bbd70a4a05074098');
+<?php return array('dependencies' => array('react', 'wp-i18n', 'wp-plugins'), 'version' => 'c30059576042eea38880');

--- a/build/dlx-pw-preview.js
+++ b/build/dlx-pw-preview.js
@@ -138,7 +138,7 @@ var PatternPreviewButton = function PatternPreviewButton() {
     // Create the button.
     var button = document.createElement('a');
     button.className = 'dlx-button-preview components-button has-icon';
-    button.ariaLabel = (0,_wordpress_i18n__WEBPACK_IMPORTED_MODULE_1__.__)('Preview', 'futuris-demo-importer');
+    button.ariaLabel = (0,_wordpress_i18n__WEBPACK_IMPORTED_MODULE_1__.__)('Preview', 'dlx-pattern-wrangler');
     button.href = dlxPatternWranglerPreview.previewUrl;
     button.target = '_blank';
     button.rel = 'noopener noreferrer';

--- a/build/index.asset.php
+++ b/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react', 'wp-i18n', 'wp-plugins'), 'version' => 'c12991944f7fcbcff0d1');
+<?php return array('dependencies' => array('react', 'wp-i18n', 'wp-plugins'), 'version' => '9165383a9b85136eb360');

--- a/build/index.js
+++ b/build/index.js
@@ -40,7 +40,7 @@ var PatternPreviewButton = function PatternPreviewButton() {
     // Create the button.
     var button = document.createElement('a');
     button.className = 'dlx-button-preview components-button has-icon';
-    button.ariaLabel = (0,_wordpress_i18n__WEBPACK_IMPORTED_MODULE_1__.__)('Preview', 'futuris-demo-importer');
+    button.ariaLabel = (0,_wordpress_i18n__WEBPACK_IMPORTED_MODULE_1__.__)('Preview', 'dlx-pattern-wrangler');
     button.href = dlxPatternWranglerPreview.previewUrl;
     button.target = '_blank';
     button.rel = 'noopener noreferrer';

--- a/php/Options.php
+++ b/php/Options.php
@@ -108,6 +108,8 @@ class Options {
 			'categories'                   => array(),
 			'allowFrontendPatternPreview'  => true,
 			'hideUncategorizedPatterns'    => false,
+			'showCustomizerUI'             => true,
+			'showMenusUI'                  => true,
 			'loadCustomizerCSSBlockEditor' => false,
 			'loadCustomizerCSSFrontend'    => true,
 			'licenseValid'                 => false,

--- a/php/Patterns.php
+++ b/php/Patterns.php
@@ -51,6 +51,18 @@ class Patterns {
 		// Add a featured image to the wp_block post type column.
 		add_action( 'manage_wp_block_posts_custom_column', array( $this, 'add_featured_image_column_content' ), 10, 2 );
 
+		// Show the customizer UI if enabled.
+		$show_customizer_ui = (bool) $options['showCustomizerUI'];
+		if ( $show_customizer_ui ) {
+			add_action( 'customize_register', '__return_true' );
+		}
+
+		// Show the menu UI if enabled.
+		$show_menu_ui = (bool) $options['showMenusUI'];
+		if ( $show_menu_ui ) {
+			add_action( 'after_setup_theme', array( $this, 'enable_menus_ui' ), 100 );
+		}
+
 		$hide_all_patterns = (bool) $options['hideAllPatterns'];
 		if ( $hide_all_patterns ) {
 			add_action( 'init', array( $this, 'remove_core_patterns' ), 9 );
@@ -69,6 +81,13 @@ class Patterns {
 			add_action( 'init', array( $this, 'remove_core_patterns' ), 9 );
 			remove_action( 'init', '_register_core_block_patterns_and_categories' );
 		}
+	}
+
+	/**
+	 * Enable menus UI.
+	 */
+	public function enable_menus_ui() {
+		add_theme_support( 'menus' );
 	}
 
 	/**

--- a/src/js/react/views/main/main.js
+++ b/src/js/react/views/main/main.js
@@ -219,8 +219,10 @@ const Interface = ( props ) => {
 			disablePatternImporterBlock: data.disablePatternImporterBlock,
 			allowFrontendPatternPreview: data.allowFrontendPatternPreview,
 			hideUncategorizedPatterns: data.hideUncategorizedPatterns,
+			showCustomizerUI: data.showCustomizerUI,
 			loadCustomizerCSSBlockEditor: data.loadCustomizerCSSBlockEditor,
 			loadCustomizerCSSFrontend: data.loadCustomizerCSSFrontend,
+			showMenusUI: data.showMenusUI,
 			categories: data.categories ?? [],
 			saveNonce: dlxPatternWranglerAdmin.saveNonce,
 			resetNonce: dlxPatternWranglerAdmin.resetNonce,
@@ -388,6 +390,22 @@ const Interface = ( props ) => {
 								<td>
 									<div className="dlx-admin__row">
 										<Controller
+											name="showCustomizerUI"
+											control={ control }
+											render={ ( { field: { onChange, value } } ) => (
+												<ToggleControl
+													label={ __( 'Show Customizer UI', 'dlx-pattern-wrangler' ) }
+													checked={ value }
+													onChange={ ( boolValue ) => {
+														onChange( boolValue );
+													} }
+													help={ __( 'This will show the customizer UI in the Appearance menu if enabled.', 'dlx-pattern-wrangler' ) }
+												/>
+											) }
+										/>
+									</div>
+									<div className="dlx-admin__row">
+										<Controller
 											name="loadCustomizerCSSBlockEditor"
 											control={ control }
 											render={ ( { field: { onChange, value } } ) => (
@@ -425,6 +443,22 @@ const Interface = ( props ) => {
 									{ __( 'Miscellaneous', 'dlx-pattern-wrangler' ) }
 								</th>
 								<td>
+									<div className="dlx-admin__row">
+										<Controller
+											name="showMenusUI"
+											control={ control }
+											render={ ( { field: { onChange, value } } ) => (
+												<ToggleControl
+													label={ __( 'Show Menus UI', 'dlx-pattern-wrangler' ) }
+													checked={ value }
+													onChange={ ( boolValue ) => {
+														onChange( boolValue );
+													} }
+													help={ __( 'This will show the menus UI in the Appearance menu if enabled.', 'dlx-pattern-wrangler' ) }
+												/>
+											) }
+										/>
+									</div>
 									<div className="dlx-admin__row">
 										<Controller
 											name="disablePatternImporterBlock"


### PR DESCRIPTION
This PR re-adds the customizer and menu items in the Appearance menu item when enabled.

Resolves #19 

Test this with a FSE theme. Please note that disabling the UI options does not hide the customizer/menu if FSE is not enabled.