### PR TITLE
Prevent Customizer CSS from Loading on the frontend

### DIFF
--- a/php/Admin.php
+++ b/php/Admin.php
@@ -60,7 +60,7 @@ class Admin {
 		}
 		// Since by default wp_custom_css_cb is add_action wp_head, just remove_action.
 		if ( ! (bool) $options['loadCustomizerCSSFrontend'] ) {
-			remove_action('wp_head', 'wp_custom_css_cb', 101);
+			remove_action( 'wp_head', 'wp_custom_css_cb', 101 );
 		}
 	}
 


### PR DESCRIPTION
Description/Update
- Updated enqueue block editor to only add the custom css for block editor by adding is_admin()
- Added condition if option `loadCustomizerCSSFrontend` is false then remove wp_custom_css_cb where it add the custom css via frontend it also include in preview.

Issue #21 