### PR TITLE
Upgrade Fancybox and enhance pattern previews

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@babel/plugin-transform-class-properties": "^7.23.3",
     "@babel/preset-env": "^7.18.2",
     "@babel/preset-react": "^7.17.12",
+    "@fancyapps/ui": "^6.1.14",
     "@mediaron/react-spinners": "^0.1.4",
     "@tanstack/react-router": "^1.130.12",
     "@types/photoswipe": "^4.1.2",
@@ -75,7 +76,6 @@
     "webpack-remove-empty-scripts": "^0.8.1"
   },
   "dependencies": {
-    "@fancyapps/ui": "^5.0.36",
     "@tanstack/react-query": "^5.84.1",
     "@wordpress/a11y": "^3.11.0",
     "@wordpress/block-editor": "^14.4.0",

--- a/src/js/fancybox/index.js
+++ b/src/js/fancybox/index.js
@@ -1,21 +1,23 @@
-import {Fancybox }  from '@fancyapps/ui/dist/fancybox/fancybox.umd.js';
-import "@fancyapps/ui/dist/fancybox/fancybox.css";
+import { Fancybox } from '@fancyapps/ui/dist/fancybox/fancybox.js';
+import '@fancyapps/ui/dist/fancybox/fancybox.css';
 
-document.addEventListener("DOMContentLoaded", function () {
+document.addEventListener( 'DOMContentLoaded', () => {
 	const patternPreviews = document.querySelectorAll( '.admin-fancybox' );
 	if ( null !== patternPreviews ) {
-		patternPreviews.forEach( function ( patternPreview ) {
-			patternPreview.addEventListener( 'click', function ( event ) {
+		patternPreviews.forEach( ( patternPreview ) => {
+			patternPreview.addEventListener( 'click', ( event ) => {
 				event.preventDefault();
 				const anchor = event.target.closest( 'a' );
-				Fancybox.show( [ {
-					src: anchor.href,
-					caption: anchor.title,
-					type: 'image',
-					zoom: false,
-					compact: true,
-					width: '60%',
-				} ] );
+				Fancybox.show( [
+					{
+						src: anchor.href,
+						caption: anchor.title,
+						type: 'image',
+						zoom: false,
+						compact: true,
+						width: '60%',
+					},
+				] );
 			} );
 		} );
 	}

--- a/src/js/react/views/categories/components/CategoriesListView.js
+++ b/src/js/react/views/categories/components/CategoriesListView.js
@@ -4,31 +4,24 @@ import {
 	useMemo,
 	useEffect,
 } from '@wordpress/element';
-import { useResizeObserver } from '@wordpress/compose';
-import { downloadBlob } from '@wordpress/blob';
-import { Fancybox } from '@fancyapps/ui/dist/fancybox/fancybox.umd.js';
-import { escapeAttribute } from '@wordpress/escape-html';
-import '@fancyapps/ui/dist/fancybox/fancybox.css';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import {
 	Button,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControl as ToggleGroupControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
-	FormFileUpload,
 } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
-import { DataViews } from '@wordpress/dataviews';
-import { Eye } from 'lucide-react';
 import {
 	addQueryArgs,
 	getQueryArgs,
 	getQueryArg,
 	removeQueryArgs,
-	cleanForSlug,
 } from '@wordpress/url';
-import { useDispatch, useSelect, dispatch, select } from '@wordpress/data';
+import { useSelect, dispatch } from '@wordpress/data';
 import BeatLoader from 'react-spinners/BeatLoader';
-import { useForm, FormProvider, useWatch, useFormState } from 'react-hook-form';
+import { useForm, FormProvider } from 'react-hook-form';
 import Snackbar from './Snackbar';
 import categoriesStore from '../store';
 import CategoryCard from './CategoryCard';
@@ -93,12 +86,6 @@ const CategoriesListView = ( props ) => {
 
 const Interface = ( props ) => {
 	const { categories } = props;
-
-	const { doNotShowAgain } = useSelect( ( newSelect ) => {
-		return {
-			doNotShowAgain: newSelect( categoriesStore ).getDoNotShowAgain(),
-		};
-	} );
 
 	const [ isAddNewCategoryModalOpen, setIsAddNewCategoryModalOpen ] =
 		useState( false );

--- a/src/js/react/views/patterns/components/PatternDuplicateModal/index.js
+++ b/src/js/react/views/patterns/components/PatternDuplicateModal/index.js
@@ -4,18 +4,17 @@ import {
 	TextControl,
 	Modal,
 	Button,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControl as ToggleGroupControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	FormTokenField,
 	ToggleControl,
 } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { AlertTriangle } from 'lucide-react';
-import { escapeHTML } from '@wordpress/escape-html';
-
 import { __ } from '@wordpress/i18n';
 import { useForm, Controller, useWatch, useFormState } from 'react-hook-form';
-import { cleanForSlug } from '@wordpress/url';
 
 // Local imports.
 import Notice from '../../../../components/Notice';
@@ -40,18 +39,6 @@ const PatternDuplicateModal = ( props ) => {
 	const categories = ( props.categories || [] ).map( ( category ) => {
 		return category.label || category.name;
 	} );
-	const localPatternCategories = ( props.patternCategories || [] ).map(
-		( category ) => {
-			const categorySlug = cleanForSlug(
-				category.label || category.name || category
-			);
-			// Find category label from slug.
-			const categoryObject = originalCategories.find(
-				( c ) => cleanForSlug( c.label || c.name ) === categorySlug
-			);
-			return escapeHTML( categoryObject.label );
-		}
-	);
 	const [ copyPatternId ] = useState( props.copyPatternId || 0 );
 	const [ syncedDefaultStatus ] = useState( props.syncedDefaultStatus || 'synced' );
 	const [ isSaving, setIsSaving ] = useState( false );
@@ -59,12 +46,8 @@ const PatternDuplicateModal = ( props ) => {
 
 	const {
 		control,
-		getValues,
 		handleSubmit,
-		reset,
 		setError,
-		trigger,
-		setValue,
 	} = useForm( {
 		defaultValues: {
 			patternId: props.item?.id || 0,
@@ -76,8 +59,9 @@ const PatternDuplicateModal = ( props ) => {
 			editPatternAfterDuplicating: props.editPatternAfterDuplicating || true,
 		},
 	} );
+	// eslint-disable-next-line no-unused-vars
 	const formValues = useWatch( { control } );
-	const { errors, isDirty, dirtyFields } = useFormState( {
+	const { errors } = useFormState( {
 		control,
 	} );
 

--- a/src/js/react/views/patterns/components/PatternsGrid.js
+++ b/src/js/react/views/patterns/components/PatternsGrid.js
@@ -1,5 +1,11 @@
 /* eslint-disable react/no-unknown-property */
-import { useState, useMemo, useEffect, useRef } from '@wordpress/element';
+import {
+	useState,
+	useMemo,
+	useEffect,
+	useRef,
+	useCallback,
+} from '@wordpress/element';
 import { downloadBlob } from '@wordpress/blob';
 import { escapeAttribute } from '@wordpress/escape-html';
 import { __, _n, sprintf, _x } from '@wordpress/i18n';
@@ -33,6 +39,7 @@ import PatternTagModal from './PatternTagModal';
 import patternsStore from '../store';
 import createPatternFromFile from '../utils/createPatternFromFile';
 import ResponsiveIframe from './ResponsiveIframe';
+import { canonicalPatternId, patternIdsEqual } from '../utils/patternIdUtils';
 
 const defaultLayouts = {
 	grid: {
@@ -207,29 +214,6 @@ const Interface = ( props ) => {
 		setPreviewQueueState( nextState );
 	};
 
-	useEffect( () => {
-		const onPreviewDeleteRequest = ( event ) => {
-			const patternId = event.detail?.patternId;
-			if ( ! patternId ) {
-				return;
-			}
-			const pattern = patterns.find( ( p ) => p.id === patternId );
-			if ( pattern && pattern.isLocal ) {
-				setIsDeleteModalOpen( { items: [ pattern ] } );
-			}
-		};
-		document.addEventListener(
-			'dlxpw-pattern-preview-delete-request',
-			onPreviewDeleteRequest
-		);
-		return () => {
-			document.removeEventListener(
-				'dlxpw-pattern-preview-delete-request',
-				onPreviewDeleteRequest
-			);
-		};
-	}, [ patterns ] );
-
 	const promoteQueuedPreviews = ( currentStatusById ) => {
 		const nextStatusById = { ...currentStatusById };
 
@@ -264,7 +248,9 @@ const Interface = ( props ) => {
 			return;
 		}
 
-		const pattern = patternsDisplay.find( ( item ) => item.id === patternId );
+		const pattern = patternsDisplay.find( ( item ) =>
+			patternIdsEqual( item.id, patternId )
+		);
 
 		if ( pattern && status === 'settled' ) {
 			loadedPreviewSignaturesRef.current.add( getPreviewSignature( pattern ) );
@@ -293,7 +279,7 @@ const Interface = ( props ) => {
 		} );
 	};
 
-	const exportPattern = ( item ) => {
+	const exportPattern = useCallback( ( item ) => {
 		const isLocal = item.isLocal;
 		const title = item.title;
 		let syncStatus = 'unsynced';
@@ -313,7 +299,112 @@ const Interface = ( props ) => {
 			2
 		);
 		downloadBlob( `${ title }.json`, fileContent, 'application/json' );
-	};
+	}, [] );
+
+	const getPatternFromPreviewEvent = useCallback(
+		( patternId ) => {
+			if ( '' === canonicalPatternId( patternId ) ) {
+				return undefined;
+			}
+			return patterns.find( ( p ) => patternIdsEqual( p.id, patternId ) );
+		},
+		[ patterns ]
+	);
+
+	useEffect( () => {
+		const onPreviewDeleteRequest = ( event ) => {
+			const pattern = getPatternFromPreviewEvent(
+				event.detail?.patternId
+			);
+			if ( pattern && pattern.isLocal ) {
+				setIsDeleteModalOpen( { items: [ pattern ] } );
+			}
+		};
+
+		const onPreviewDisableRequest = ( event ) => {
+			const pattern = getPatternFromPreviewEvent(
+				event.detail?.patternId
+			);
+			if ( pattern && ! pattern.isLocal && ! pattern.isDisabled ) {
+				setIsPauseModalOpen( { items: [ pattern ] } );
+			}
+		};
+
+		const onPreviewEditRequest = ( event ) => {
+			const pattern = getPatternFromPreviewEvent(
+				event.detail?.patternId
+			);
+			if ( pattern && pattern.isLocal && ! pattern.isDisabled ) {
+				const redirectUrl = encodeURIComponent(
+					window.location.href
+				);
+				window.location.href = `${ dlxEnhancedPatternsView.getSiteBaseUrl }post.php?post=${ pattern.id }&action=edit&redirect_to=${ redirectUrl }`;
+			}
+		};
+
+		const onPreviewExportRequest = ( event ) => {
+			const pattern = getPatternFromPreviewEvent(
+				event.detail?.patternId
+			);
+			if ( pattern ) {
+				exportPattern( pattern );
+			}
+		};
+
+		const onPreviewCopyRequest = ( event ) => {
+			const pattern = getPatternFromPreviewEvent(
+				event.detail?.patternId
+			);
+			if ( pattern && ! pattern.isLocal ) {
+				setCopyPatternId( pattern.id );
+				setIsCopyToLocalModalOpen( { item: pattern } );
+			}
+		};
+
+		document.addEventListener(
+			'dlxpw-pattern-preview-delete-request',
+			onPreviewDeleteRequest
+		);
+		document.addEventListener(
+			'dlxpw-pattern-preview-disable-request',
+			onPreviewDisableRequest
+		);
+		document.addEventListener(
+			'dlxpw-pattern-preview-edit-request',
+			onPreviewEditRequest
+		);
+		document.addEventListener(
+			'dlxpw-pattern-preview-export-request',
+			onPreviewExportRequest
+		);
+		document.addEventListener(
+			'dlxpw-pattern-preview-copy-request',
+			onPreviewCopyRequest
+		);
+
+		return () => {
+			document.removeEventListener(
+				'dlxpw-pattern-preview-delete-request',
+				onPreviewDeleteRequest
+			);
+			document.removeEventListener(
+				'dlxpw-pattern-preview-disable-request',
+				onPreviewDisableRequest
+			);
+			document.removeEventListener(
+				'dlxpw-pattern-preview-edit-request',
+				onPreviewEditRequest
+			);
+			document.removeEventListener(
+				'dlxpw-pattern-preview-export-request',
+				onPreviewExportRequest
+			);
+			document.removeEventListener(
+				'dlxpw-pattern-preview-copy-request',
+				onPreviewCopyRequest
+			);
+		};
+	}, [ patterns, exportPattern, getPatternFromPreviewEvent ] );
 
 	/**
 	 * Returns a default view with query vars. Useful for setting or refreshing the view.
@@ -848,7 +939,11 @@ const Interface = ( props ) => {
 					const viewportWidth = item.viewportWidth || 1200;
 
 					const previewUrl = item?.id
-						? `${ ajaxurl }?action=dlxpw_pattern_preview&pattern_id=${ item.id }&viewport_width=${ viewportWidth }`
+						? addQueryArgs( ajaxurl, {
+							action: 'dlxpw_pattern_preview',
+							pattern_id: item.id,
+							viewport_width: viewportWidth,
+						} )
 						: '';
 
 					// Determine badge type based on pattern properties.

--- a/src/js/react/views/patterns/components/PatternsGrid.js
+++ b/src/js/react/views/patterns/components/PatternsGrid.js
@@ -207,6 +207,29 @@ const Interface = ( props ) => {
 		setPreviewQueueState( nextState );
 	};
 
+	useEffect( () => {
+		const onPreviewDeleteRequest = ( event ) => {
+			const patternId = event.detail?.patternId;
+			if ( ! patternId ) {
+				return;
+			}
+			const pattern = patterns.find( ( p ) => p.id === patternId );
+			if ( pattern && pattern.isLocal ) {
+				setIsDeleteModalOpen( { items: [ pattern ] } );
+			}
+		};
+		document.addEventListener(
+			'dlxpw-pattern-preview-delete-request',
+			onPreviewDeleteRequest
+		);
+		return () => {
+			document.removeEventListener(
+				'dlxpw-pattern-preview-delete-request',
+				onPreviewDeleteRequest
+			);
+		};
+	}, [ patterns ] );
+
 	const promoteQueuedPreviews = ( currentStatusById ) => {
 		const nextStatusById = { ...currentStatusById };
 
@@ -460,6 +483,264 @@ const Interface = ( props ) => {
 		return defaultView;
 	} );
 
+	/**
+	 * Filtered and sorted patterns for the current view (full list, no pagination).
+	 *
+	 * @param {Object} newView The view object.
+	 * @return {Array} Patterns in display order.
+	 */
+	const getFilteredPatternsOrdered = ( newView ) => {
+		let patternsCopy = [ ...patterns ];
+
+		if ( null === patternsCopy || 0 === patternsCopy.length ) {
+			patternsCopy = [ ...data.patterns ];
+		}
+
+		const orderBy = newView?.sort?.field;
+		const order = newView?.sort?.direction;
+
+		if ( 'title' === orderBy ) {
+			if ( 'desc' === order ) {
+				patternsCopy.sort( ( a, b ) => b.title.localeCompare( a.title ) );
+			} else {
+				patternsCopy.sort( ( a, b ) => a.title.localeCompare( b.title ) );
+			}
+		}
+
+		const filters = newView?.filters || [];
+		if ( filters.length > 0 ) {
+			filters.forEach( ( filter ) => {
+				switch ( filter.field ) {
+					case 'categories':
+						if ( filter.value ) {
+							const cleanedFilterValues = filter.value.map( ( value ) =>
+								cleanForSlug( value )
+							);
+
+							if ( filter.operator === 'isAny' ) {
+								patternsCopy = patternsCopy.filter( ( pattern ) => {
+									const patternCategories = pattern.categorySlugs || [];
+									return patternCategories.some( ( category ) => {
+										const tempSlug =
+											category.name ||
+											category.label ||
+											category.toString() ||
+											'';
+										const categoryToCheck = cleanForSlug( tempSlug );
+										return cleanedFilterValues.includes( categoryToCheck );
+									} );
+								} );
+							} else if ( filter.operator === 'isNone' ) {
+								patternsCopy = patternsCopy.filter( ( pattern ) => {
+									const patternCategories = pattern.categorySlugs || [];
+
+									const hasExcludedCategory = patternCategories.some(
+										( category ) => {
+											const tempSlug =
+												category.name ||
+												category.label ||
+												category.toString() ||
+												'';
+											const categoryToCheck = cleanForSlug( tempSlug );
+											return cleanedFilterValues.includes( categoryToCheck );
+										}
+									);
+
+									return ! hasExcludedCategory;
+								} );
+							}
+						}
+						break;
+					case 'assets':
+						if ( filter.value && filter.operator === 'is' ) {
+							patternsCopy = patternsCopy.filter( ( pattern ) => {
+								return pattern.asset === filter.value;
+							} );
+						}
+						break;
+					case 'patternType':
+						if ( filter.value ) {
+							switch ( filter.value ) {
+								case 'all':
+									break;
+								case 'local':
+									patternsCopy = patternsCopy.filter(
+										( pattern ) => pattern.isLocal
+									);
+									break;
+								case 'registered':
+									patternsCopy = patternsCopy.filter(
+										( pattern ) => ! pattern.isLocal
+									);
+									break;
+							}
+						}
+						break;
+					case 'patternStatus':
+						if ( filter.value ) {
+							const patternTypeFilter = filters.find(
+								( f ) => f.field === 'patternType'
+							);
+							if (
+								patternTypeFilter &&
+								patternTypeFilter.value === 'local' &&
+								filter.value
+							) {
+								switch ( filter.value ) {
+									case 'unsynced':
+										patternsCopy = patternsCopy.filter( ( pattern ) => {
+											if ( pattern.syncStatus ) {
+												return (
+													pattern.syncStatus === 'unsynced' && pattern.isLocal
+												);
+											}
+											return false;
+										} );
+										break;
+									case 'synced':
+										patternsCopy = patternsCopy.filter( ( pattern ) => {
+											if ( pattern.syncStatus ) {
+												return (
+													pattern.syncStatus === 'synced' && pattern.isLocal
+												);
+											}
+											return false;
+										} );
+										break;
+									case 'both':
+										break;
+								}
+							}
+						}
+						break;
+					case 'patternLocalStatus':
+						if ( filter.value ) {
+							const patternTypeFilter = filters.find(
+								( f ) => f.field === 'patternType'
+							);
+							if (
+								patternTypeFilter &&
+								patternTypeFilter.value === 'local' &&
+								filter.value
+							) {
+								switch ( filter.value ) {
+									case 'draft':
+									case 'paused':
+										patternsCopy = patternsCopy.filter( ( pattern ) => {
+											return pattern.isDisabled && pattern.isLocal;
+										} );
+										break;
+									case 'published':
+										patternsCopy = patternsCopy.filter( ( pattern ) => {
+											return ! pattern.isDisabled && pattern.isLocal;
+										} );
+										break;
+									case 'both':
+										break;
+								}
+							}
+						}
+						break;
+					case 'patternRegisteredStatus':
+						if ( filter.value ) {
+							const patternTypeFilter = filters.find(
+								( f ) => f.field === 'patternType'
+							);
+							if (
+								patternTypeFilter &&
+								patternTypeFilter.value === 'registered' &&
+								filter.value
+							) {
+								switch ( filter.value ) {
+									case 'paused':
+										patternsCopy = patternsCopy.filter( ( pattern ) => {
+											return pattern.isDisabled && ! pattern.isLocal;
+										} );
+										break;
+									case 'unpaused':
+										patternsCopy = patternsCopy.filter( ( pattern ) => {
+											return ! pattern.isDisabled && ! pattern.isLocal;
+										} );
+										break;
+									case 'both':
+										break;
+								}
+							}
+						}
+						break;
+					case 'patternLocalRegisteredStatus':
+						if ( filter.value ) {
+							const patternTypeFilter = filters.find(
+								( f ) => f.field === 'patternType'
+							);
+							if (
+								patternTypeFilter &&
+								patternTypeFilter.value === 'all' &&
+								filter.value
+							) {
+								switch ( filter.value ) {
+									case 'disabled':
+										patternsCopy = patternsCopy.filter( ( pattern ) => {
+											return pattern.isDisabled;
+										} );
+										break;
+									case 'enabled':
+										patternsCopy = patternsCopy.filter( ( pattern ) => {
+											return ! pattern.isDisabled;
+										} );
+										break;
+									case 'both':
+										break;
+								}
+							}
+						}
+						break;
+				}
+			} );
+		}
+
+		const searchField = newView?.search || '';
+
+		if ( 'undefined' !== searchField && '' !== searchField ) {
+			patternsCopy = patternsCopy.filter( ( pattern ) => {
+				const patternLabel = pattern.label || pattern.title;
+				return patternLabel
+					.toLowerCase()
+					.includes( ( newView.search || searchField ).toLowerCase() );
+			} );
+		}
+
+		return patternsCopy;
+	};
+
+	/**
+	 * Get the total count of filtered patterns without pagination.
+	 *
+	 * @param {Object} newView The new view object.
+	 * @return {number} The total count of filtered patterns.
+	 */
+	const getFilteredPatternsCount = ( newView ) => {
+		return getFilteredPatternsOrdered( newView ).length;
+	};
+
+	/**
+	 * Retrieve a list of modified patterns based on query vars and the current view (paginated).
+	 *
+	 * @param {Object} newView The new view object.
+	 * @return {Array} The patterns for display.
+	 */
+	const getPatternsForDisplay = ( newView ) => {
+		const ordered = getFilteredPatternsOrdered( newView );
+		return ordered.slice(
+			( newView.page - 1 ) * newView.perPage,
+			newView.page * newView.perPage
+		);
+	};
+
+	const lightboxGalleryItems = useMemo( () => {
+		return getFilteredPatternsOrdered( view );
+	}, [ view, patterns, data?.patterns ] );
+
 	const fields = useMemo(
 		() => [
 			{
@@ -619,6 +900,7 @@ const Interface = ( props ) => {
 										src={ previewUrl }
 										title={ `Preview: ${ item.title }` }
 										item={ item }
+										galleryItems={ patternsDisplay ?? lightboxGalleryItems }
 										queueGeneration={ previewQueueState.generation }
 										queueStatus={ previewStatus }
 										onPreviewSettled={ ( patternId, generation ) => {
@@ -823,7 +1105,7 @@ const Interface = ( props ) => {
 				label: __( 'Pattern Local and Registered Status', 'pattern-wrangler' ),
 			},
 		],
-		[ nonEmptyCategories, patternsDisplay, previewQueueState ]
+		[ nonEmptyCategories, patternsDisplay, previewQueueState, lightboxGalleryItems ]
 	);
 
 	const actions = useMemo(
@@ -1105,486 +1387,6 @@ const Interface = ( props ) => {
 		],
 		[ categories, patterns ]
 	);
-
-	/**
-	 * Get the total count of filtered patterns without pagination.
-	 *
-	 * @param {Object} newView The new view object.
-	 * @return {number} The total count of filtered patterns.
-	 */
-	const getFilteredPatternsCount = ( newView ) => {
-		let patternsCopy = [ ...patterns ];
-
-		if ( null === patternsCopy || 0 === patternsCopy.length ) {
-			patternsCopy = [ ...data.patterns ];
-		}
-
-		const orderBy = newView?.sort?.field;
-		const order = newView?.sort?.direction;
-
-		if ( 'title' === orderBy ) {
-			if ( 'desc' === order ) {
-				patternsCopy.sort( ( a, b ) => b.title.localeCompare( a.title ) );
-			} else {
-				patternsCopy.sort( ( a, b ) => a.title.localeCompare( b.title ) );
-			}
-		}
-
-		// Filter by categories.
-		const filters = newView?.filters || [];
-		if ( filters.length > 0 ) {
-			filters.forEach( ( filter ) => {
-				switch ( filter.field ) {
-					case 'categories':
-						if ( filter.value ) {
-							// filter.value is an array.
-							// Clean the filter values once for efficiency
-							const cleanedFilterValues = filter.value.map( ( value ) =>
-								cleanForSlug( value )
-							);
-
-							if ( filter.operator === 'isAny' ) {
-								patternsCopy = patternsCopy.filter( ( pattern ) => {
-									const patternCategories = pattern.categorySlugs || [];
-									return patternCategories.some( ( category ) => {
-										const tempSlug =
-											category.name ||
-											category.label ||
-											category.toString() ||
-											'';
-										const categoryToCheck = cleanForSlug( tempSlug );
-										return cleanedFilterValues.includes( categoryToCheck );
-									} );
-								} );
-							} else if ( filter.operator === 'isNone' ) {
-								patternsCopy = patternsCopy.filter( ( pattern ) => {
-									const patternCategories = pattern.categorySlugs || [];
-
-									// Exclude patterns that have ANY of the categories in filter.value
-									// Check if this pattern has any excluded categories
-									const hasExcludedCategory = patternCategories.some(
-										( category ) => {
-											const tempSlug =
-												category.name ||
-												category.label ||
-												category.toString() ||
-												'';
-											const categoryToCheck = cleanForSlug( tempSlug );
-											return cleanedFilterValues.includes( categoryToCheck );
-										}
-									);
-
-									// Return true to keep the pattern only if it has NO excluded categories
-									return ! hasExcludedCategory;
-								} );
-							}
-						}
-						break;
-					case 'assets':
-						if ( filter.value ) {
-							if ( filter.operator === 'is' ) {
-								patternsCopy = patternsCopy.filter( ( pattern ) => {
-									return pattern.asset === filter.value;
-								} );
-							}
-						}
-						break;
-					case 'patternType':
-						if ( filter.value ) {
-							switch ( filter.value ) {
-								case 'all':
-									break;
-								case 'local':
-									patternsCopy = patternsCopy.filter(
-										( pattern ) => pattern.isLocal
-									);
-									break;
-								case 'registered':
-									patternsCopy = patternsCopy.filter(
-										( pattern ) => ! pattern.isLocal
-									);
-									break;
-							}
-						}
-						break;
-					case 'patternStatus':
-						if ( filter.value ) {
-							const patternTypeFilter = filters.find(
-								( f ) => f.field === 'patternType'
-							);
-							if (
-								patternTypeFilter &&
-								patternTypeFilter.value === 'local' &&
-								filter.value
-							) {
-								switch ( filter.value ) {
-									case 'unsynced':
-										patternsCopy = patternsCopy.filter( ( pattern ) => {
-											if ( pattern.syncStatus ) {
-												return (
-													pattern.syncStatus === 'unsynced' && pattern.isLocal
-												);
-											}
-											return false;
-										} );
-										break;
-									case 'synced':
-										patternsCopy = patternsCopy.filter( ( pattern ) => {
-											if ( pattern.syncStatus ) {
-												return (
-													pattern.syncStatus === 'synced' && pattern.isLocal
-												);
-											}
-											return false;
-										} );
-										break;
-									case 'both':
-										break;
-								}
-							}
-						}
-						break;
-					case 'patternLocalStatus':
-						if ( filter.value ) {
-							const patternTypeFilter = filters.find(
-								( f ) => f.field === 'patternType'
-							);
-							if (
-								patternTypeFilter &&
-								patternTypeFilter.value === 'local' &&
-								filter.value
-							) {
-								switch ( filter.value ) {
-									case 'draft':
-										patternsCopy = patternsCopy.filter( ( pattern ) => {
-											return pattern.isDisabled && pattern.isLocal;
-										} );
-										break;
-									case 'published':
-										patternsCopy = patternsCopy.filter( ( pattern ) => {
-											return ! pattern.isDisabled && pattern.isLocal;
-										} );
-										break;
-									case 'both':
-										break;
-								}
-							}
-						}
-						break;
-					case 'patternRegisteredStatus':
-						if ( filter.value ) {
-							const patternTypeFilter = filters.find(
-								( f ) => f.field === 'patternType'
-							);
-							if (
-								patternTypeFilter &&
-								patternTypeFilter.value === 'registered' &&
-								filter.value
-							) {
-								switch ( filter.value ) {
-									case 'paused':
-										patternsCopy = patternsCopy.filter( ( pattern ) => {
-											return pattern.isDisabled && ! pattern.isLocal;
-										} );
-										break;
-									case 'unpaused':
-										patternsCopy = patternsCopy.filter( ( pattern ) => {
-											return ! pattern.isDisabled && ! pattern.isLocal;
-										} );
-										break;
-									case 'both':
-										break;
-								}
-							}
-						}
-						break;
-					case 'patternLocalRegisteredStatus':
-						if ( filter.value ) {
-							const patternTypeFilter = filters.find(
-								( f ) => f.field === 'patternType'
-							);
-							if (
-								patternTypeFilter &&
-								patternTypeFilter.value === 'all' &&
-								filter.value
-							) {
-								switch ( filter.value ) {
-									case 'disabled':
-										patternsCopy = patternsCopy.filter( ( pattern ) => {
-											return pattern.isDisabled;
-										} );
-										break;
-									case 'enabled':
-										patternsCopy = patternsCopy.filter( ( pattern ) => {
-											return ! pattern.isDisabled;
-										} );
-										break;
-									case 'both':
-										break;
-								}
-							}
-						}
-						break;
-				}
-			} );
-		}
-
-		// Do search.
-		const searchField = newView?.search || '';
-
-		if ( 'undefined' !== searchField && '' !== searchField ) {
-			patternsCopy = patternsCopy.filter( ( pattern ) => {
-				const patternLabel = pattern.label || pattern.title;
-				return patternLabel
-					.toLowerCase()
-					.includes( ( newView.search || searchField ).toLowerCase() );
-			} );
-		}
-
-		// Return the total count without pagination.
-		return patternsCopy.length;
-	};
-
-	/**
-	 * Retrieve a list of modified patterns based on query vars and the current view.
-	 *
-	 * @param {Object} newView The new view object.
-	 * @return {Array} The patterns for display.
-	 */
-	const getPatternsForDisplay = ( newView ) => {
-		let patternsCopy = [ ...patterns ];
-
-		if ( null === patternsCopy || 0 === patternsCopy.length ) {
-			patternsCopy = [ ...data.patterns ];
-		}
-
-		const orderBy = newView?.sort?.field;
-		const order = newView?.sort?.direction;
-
-		if ( 'title' === orderBy ) {
-			if ( 'desc' === order ) {
-				patternsCopy.sort( ( a, b ) => b.title.localeCompare( a.title ) );
-			} else {
-				patternsCopy.sort( ( a, b ) => a.title.localeCompare( b.title ) );
-			}
-		}
-
-		// Filter by categories.
-		const filters = newView?.filters || [];
-		if ( filters.length > 0 ) {
-			filters.forEach( ( filter ) => {
-				switch ( filter.field ) {
-					case 'categories':
-						if ( filter.value ) {
-							// filter.value is an array.
-							// Clean the filter values once for efficiency
-							const cleanedFilterValues = filter.value.map( ( value ) =>
-								cleanForSlug( value )
-							);
-
-							if ( filter.operator === 'isAny' ) {
-								patternsCopy = patternsCopy.filter( ( pattern ) => {
-									const patternCategories = pattern.categorySlugs || [];
-									return patternCategories.some( ( category ) => {
-										const tempSlug =
-											category.name ||
-											category.label ||
-											category.toString() ||
-											'';
-										const categoryToCheck = cleanForSlug( tempSlug );
-										return cleanedFilterValues.includes( categoryToCheck );
-									} );
-								} );
-							} else if ( filter.operator === 'isNone' ) {
-								patternsCopy = patternsCopy.filter( ( pattern ) => {
-									const patternCategories = pattern.categorySlugs || [];
-
-									// Exclude patterns that have ANY of the categories in filter.value
-									// Check if this pattern has any excluded categories
-									const hasExcludedCategory = patternCategories.some(
-										( category ) => {
-											const tempSlug =
-												category.name ||
-												category.label ||
-												category.toString() ||
-												'';
-											const categoryToCheck = cleanForSlug( tempSlug );
-											return cleanedFilterValues.includes( categoryToCheck );
-										}
-									);
-
-									// Return true to keep the pattern only if it has NO excluded categories
-									return ! hasExcludedCategory;
-								} );
-							}
-						}
-						break;
-					case 'assets':
-						if ( filter.value ) {
-							patternsCopy = patternsCopy.filter( ( pattern ) => {
-								return pattern.asset === filter.value;
-							} );
-						}
-						break;
-					case 'patternType':
-						if ( filter.value ) {
-							switch ( filter.value ) {
-								case 'all':
-									break;
-								case 'local':
-									patternsCopy = patternsCopy.filter(
-										( pattern ) => pattern.isLocal
-									);
-									break;
-								case 'registered':
-									patternsCopy = patternsCopy.filter(
-										( pattern ) => ! pattern.isLocal
-									);
-									break;
-							}
-						}
-						break;
-					case 'patternStatus':
-						if ( filter.value ) {
-							const patternTypeFilter = filters.find(
-								( f ) => f.field === 'patternType'
-							);
-							if (
-								patternTypeFilter &&
-								patternTypeFilter.value === 'local' &&
-								filter.value
-							) {
-								switch ( filter.value ) {
-									case 'unsynced':
-										patternsCopy = patternsCopy.filter( ( pattern ) => {
-											if ( pattern.syncStatus ) {
-												return (
-													pattern.syncStatus === 'unsynced' && pattern.isLocal
-												);
-											}
-											return false;
-										} );
-										break;
-									case 'synced':
-										patternsCopy = patternsCopy.filter( ( pattern ) => {
-											if ( pattern.syncStatus ) {
-												return (
-													pattern.syncStatus === 'synced' && pattern.isLocal
-												);
-											}
-											return false;
-										} );
-										break;
-									case 'both':
-										break;
-								}
-							}
-						}
-						break;
-					case 'patternLocalStatus':
-						if ( filter.value ) {
-							const patternTypeFilter = filters.find(
-								( f ) => f.field === 'patternType'
-							);
-							if (
-								patternTypeFilter &&
-								patternTypeFilter.value === 'local' &&
-								filter.value
-							) {
-								switch ( filter.value ) {
-									case 'draft':
-									case 'paused':
-										patternsCopy = patternsCopy.filter( ( pattern ) => {
-											return pattern.isDisabled && pattern.isLocal;
-										} );
-										break;
-									case 'published':
-										patternsCopy = patternsCopy.filter( ( pattern ) => {
-											return ! pattern.isDisabled && pattern.isLocal;
-										} );
-										break;
-									case 'both':
-										break;
-								}
-							}
-						}
-						break;
-					case 'patternRegisteredStatus':
-						if ( filter.value ) {
-							const patternTypeFilter = filters.find(
-								( f ) => f.field === 'patternType'
-							);
-							if (
-								patternTypeFilter &&
-								patternTypeFilter.value === 'registered' &&
-								filter.value
-							) {
-								switch ( filter.value ) {
-									case 'paused':
-										patternsCopy = patternsCopy.filter( ( pattern ) => {
-											return pattern.isDisabled && ! pattern.isLocal;
-										} );
-										break;
-									case 'unpaused':
-										patternsCopy = patternsCopy.filter( ( pattern ) => {
-											return ! pattern.isDisabled && ! pattern.isLocal;
-										} );
-										break;
-									case 'both':
-										break;
-								}
-							}
-						}
-						break;
-					case 'patternLocalRegisteredStatus':
-						if ( filter.value ) {
-							const patternTypeFilter = filters.find(
-								( f ) => f.field === 'patternType'
-							);
-							if (
-								patternTypeFilter &&
-								patternTypeFilter.value === 'all' &&
-								filter.value
-							) {
-								switch ( filter.value ) {
-									case 'disabled':
-										patternsCopy = patternsCopy.filter( ( pattern ) => {
-											return pattern.isDisabled;
-										} );
-										break;
-									case 'enabled':
-										patternsCopy = patternsCopy.filter( ( pattern ) => {
-											return ! pattern.isDisabled;
-										} );
-										break;
-									case 'both':
-										break;
-								}
-							}
-						}
-						break;
-				}
-			} );
-		}
-
-		// Do search.
-		const searchField = newView?.search || '';
-
-		if ( 'undefined' !== searchField && '' !== searchField ) {
-			patternsCopy = patternsCopy.filter( ( pattern ) => {
-				const patternLabel = pattern.label || pattern.title;
-				return patternLabel
-					.toLowerCase()
-					.includes( ( newView.search || searchField ).toLowerCase() );
-			} );
-		}
-
-		// Return the patterns for display with pagination.
-		return patternsCopy.slice(
-			( newView.page - 1 ) * newView.perPage,
-			newView.page * newView.perPage
-		);
-	};
 
 	/**
 	 * When a view is changed, we need to adjust the fields and showMedia based on the view type.

--- a/src/js/react/views/patterns/components/PatternsGrid.js
+++ b/src/js/react/views/patterns/components/PatternsGrid.js
@@ -925,6 +925,7 @@ const Interface = ( props ) => {
 							action: 'dlxpw_pattern_preview',
 							pattern_id: item.id,
 							viewport_width: viewportWidth,
+							iframe_preview: true,
 						} )
 						: '';
 

--- a/src/js/react/views/patterns/components/PatternsGrid.js
+++ b/src/js/react/views/patterns/components/PatternsGrid.js
@@ -351,16 +351,6 @@ const Interface = ( props ) => {
 			}
 		};
 
-		const onPreviewCopyRequest = ( event ) => {
-			const pattern = getPatternFromPreviewEvent(
-				event.detail?.patternId
-			);
-			if ( pattern && ! pattern.isLocal ) {
-				setCopyPatternId( pattern.id );
-				setIsCopyToLocalModalOpen( { item: pattern } );
-			}
-		};
-
 		document.addEventListener(
 			'dlxpw-pattern-preview-delete-request',
 			onPreviewDeleteRequest
@@ -376,10 +366,6 @@ const Interface = ( props ) => {
 		document.addEventListener(
 			'dlxpw-pattern-preview-export-request',
 			onPreviewExportRequest
-		);
-		document.addEventListener(
-			'dlxpw-pattern-preview-copy-request',
-			onPreviewCopyRequest
 		);
 
 		return () => {
@@ -398,10 +384,6 @@ const Interface = ( props ) => {
 			document.removeEventListener(
 				'dlxpw-pattern-preview-export-request',
 				onPreviewExportRequest
-			);
-			document.removeEventListener(
-				'dlxpw-pattern-preview-copy-request',
-				onPreviewCopyRequest
 			);
 		};
 	}, [ patterns, exportPattern, getPatternFromPreviewEvent ] );

--- a/src/js/react/views/patterns/components/ResponsiveIframe/index.js
+++ b/src/js/react/views/patterns/components/ResponsiveIframe/index.js
@@ -77,6 +77,48 @@ const dispatchPreviewToolbarEvent = ( name, patternId ) => {
 };
 
 /**
+ * Copy the active pattern block markup to the system clipboard from the preview toolbar.
+ *
+ * @param {Object|undefined} pattern Pattern row from previewToolbarPatterns.
+ * @return {Promise<void>} Resolves when the copy attempt finishes.
+ */
+const copyPatternMarkupToClipboard = async( pattern ) => {
+	if ( ! pattern || 'string' !== typeof pattern.content ) {
+		return;
+	}
+	const text = pattern.content.trim();
+	if ( '' === text ) {
+		return;
+	}
+	let copied = false;
+	try {
+		if ( navigator.clipboard?.writeText ) {
+			await navigator.clipboard.writeText( text );
+			copied = true;
+		}
+	} catch ( e ) {
+		// Use textarea fallback below.
+	}
+	if ( ! copied ) {
+		const textarea = document.createElement( 'textarea' );
+		textarea.value = text;
+		textarea.style.position = 'fixed';
+		textarea.style.opacity = '0';
+		textarea.style.pointerEvents = 'none';
+		document.body.appendChild( textarea );
+		textarea.select();
+		try {
+			// eslint-disable-next-line-deprecation
+			document.execCommand( 'copy' );
+			copied = true;
+		} catch ( err ) {
+			copied = false;
+		}
+		document.body.removeChild( textarea );
+	}
+};
+
+/**
  * Show or hide toolbar controls from the active slide pattern.
  *
  * @param {Object} fancybox Fancybox instance from event callbacks.
@@ -112,7 +154,14 @@ const syncPreviewToolbarButtons = ( fancybox ) => {
 		!! ( pattern && pattern.isLocal )
 	);
 	setBtn( 'export', !! pattern );
-	setBtn( 'copy', !! ( pattern && ! pattern.isLocal ) );
+	setBtn(
+		'copy',
+		!! (
+			pattern &&
+			'string' === typeof pattern.content &&
+			pattern.content.trim()
+		)
+	);
 };
 
 /**
@@ -202,18 +251,15 @@ const getPatternPreviewFancyboxOptions = ( extra = {} ) => {
 		},
 		copyPattern: {
 			tpl: `<button type="button" class="f-button" title="${ __(
-				'Copy to New Pattern',
+				'Copy pattern markup',
 				'pattern-wrangler'
 			) }" data-dlxpw-toolbar="copy" aria-label="${ __(
-				'Copy to New Pattern',
+				'Copy pattern markup',
 				'pattern-wrangler'
 			) }"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button>`,
 			click: () => {
-				const id = getActivePreviewPattern()?.id;
-				dispatchPreviewToolbarEvent(
-					'dlxpw-pattern-preview-copy-request',
-					id
-				);
+				const pattern = getActivePreviewPattern();
+				void copyPatternMarkupToClipboard( pattern );
 			},
 		},
 	};

--- a/src/js/react/views/patterns/components/ResponsiveIframe/index.js
+++ b/src/js/react/views/patterns/components/ResponsiveIframe/index.js
@@ -1,35 +1,116 @@
 import { useRef, useState, useEffect } from 'react';
 import { useResizeObserver } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
 import ZoomIcon from '../Icons/ZoomIcon';
 import { ReactSpinner3 } from '@mediaron/react-spinners';
 import '@fancyapps/ui/dist/fancybox/fancybox.css';
-import { Fancybox } from '@fancyapps/ui/dist/fancybox/fancybox.umd.js';
+import '@fancyapps/ui/dist/fancybox/fancybox.sidebar.css';
+import { Fancybox } from '@fancyapps/ui/dist/fancybox/fancybox.js';
+import { Sidebar } from '@fancyapps/ui/dist/fancybox/fancybox.sidebar.js';
 
-const popPatternPreview = ( item ) => {
-	const viewportWidth = item.viewportWidth || 1200;
+/**
+ * Builds Fancybox instance options (second argument to Fancybox.show).
+ * Fancybox v6 does not read plugins, Sidebar, Carousel, closeButton, or startIndex from slide items.
+ *
+ * Merges `extra.Carousel` so gallery options (e.g. infinite) do not replace Toolbar config.
+ *
+ * @param {Object} extra Partial options merged after defaults.
+ * @return {Object} Options for Fancybox.show.
+ */
+const getPatternPreviewFancyboxOptions = ( extra = {} ) => {
+	const { Carousel: extraCarousel = {}, item, ...restExtra } = extra;
 
-	const previewUrl = item?.id
-		? `${ ajaxurl }?action=dlxpw_pattern_preview&pattern_id=${ item.id }&viewport_width=${ viewportWidth }`
+	const items = {};
+	if ( item?.isLocal ) {
+		items.deletePattern = {
+			tpl: `<button type="button" class="f-button" title="${ __(
+				'Delete pattern',
+				'pattern-wrangler'
+			) }" data-dlxpw-toolbar-delete aria-label="${ __(
+				'Delete pattern',
+				'pattern-wrangler'
+			) }"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg></button>`,
+			click: () => {
+				Fancybox.close();
+				document.dispatchEvent(
+					new CustomEvent( 'dlxpw-pattern-preview-delete-request', {
+						bubbles: true,
+						detail: { patternId: item.id },
+					} )
+				);
+			},
+		};
+	}
+
+	return {
+		closeButton: false,
+		Carousel: {
+			Toolbar: {
+				absolute: true,
+				enabled: true,
+				display: {
+					left: [],
+					middle: [ 'deletePattern' ],
+					right: [ 'close' ],
+				},
+				items,
+			},
+			...extraCarousel,
+		},
+		...restExtra,
+	};
+};
+
+const buildPatternPreviewSlide = ( patternItem ) => {
+	const viewportWidth = patternItem.viewportWidth || 1200;
+	const previewUrl = patternItem?.id
+		? `${ ajaxurl }?action=dlxpw_pattern_preview&pattern_id=${ patternItem.id }&viewport_width=${ viewportWidth }`
 		: '';
 
-	Fancybox.show( [
-		{
-			src: previewUrl,
-			caption: item.title,
-			type: 'iframe',
-			closeButton: true,
-		},
-	] );
+	return {
+		src: previewUrl,
+		caption: patternItem.title,
+		type: 'iframe',
+	};
+};
+
+const popPatternPreview = ( item, galleryItems ) => {
+	if ( ! galleryItems || galleryItems.length < 2 ) {
+		Fancybox.show(
+			[ buildPatternPreviewSlide( item ) ],
+			getPatternPreviewFancyboxOptions()
+		);
+		return;
+	}
+
+	const slides = galleryItems.map( ( patternItem ) =>
+		buildPatternPreviewSlide( patternItem )
+	);
+	let startIndex = galleryItems.findIndex( ( p ) => p.id === item.id );
+	if ( startIndex < 0 ) {
+		startIndex = 0;
+	}
+
+	Fancybox.show(
+		slides,
+		getPatternPreviewFancyboxOptions( {
+			startIndex,
+			Carousel: {
+				infinite: false,
+			},
+			item,
+		} )
+	);
 };
 
 const ResponsiveIframe = ( {
 	src,
 	title,
 	item,
+	galleryItems = null,
 	onPreviewSettled = null,
 	onPreviewError = null,
 	queueGeneration = 0,
-	queueStatus = 'loading',
 } ) => {
 	const iframeRef = useRef( null );
 	const containerRef = useRef( null );
@@ -123,7 +204,7 @@ const ResponsiveIframe = ( {
 			rel="noopener noreferrer"
 			onClick={ ( e ) => {
 				e.preventDefault();
-				popPatternPreview( item );
+				popPatternPreview( item, galleryItems );
 			} }
 			aria-hidden="true"
 		>

--- a/src/js/react/views/patterns/components/ResponsiveIframe/index.js
+++ b/src/js/react/views/patterns/components/ResponsiveIframe/index.js
@@ -119,6 +119,34 @@ const copyPatternMarkupToClipboard = async( pattern ) => {
 };
 
 /**
+ * Visibility map for Fancybox preview toolbar keys (`data-dlxpw-toolbar`).
+ * Aligns with PatternsGrid quick links: local edit only when enabled; export always when a row exists.
+ *
+ * @param {Object|undefined} pattern Active pattern row from previewToolbarPatterns.
+ * @return {Object<string, boolean>} Keys disable, delete, edit, export, copy.
+ */
+const getPreviewToolbarButtonVisibility = ( pattern ) => {
+	if ( ! pattern ) {
+		return {
+			disable: false,
+			delete: false,
+			edit: false,
+			export: false,
+			copy: false,
+		};
+	}
+	const hasCopyableContent =
+		'string' === typeof pattern.content && pattern.content.trim();
+	return {
+		disable: ! pattern.isLocal && ! pattern.isDisabled,
+		delete: !! pattern.isLocal,
+		edit: !! pattern.isLocal && ! pattern.isDisabled,
+		export: true,
+		copy: !! hasCopyableContent,
+	};
+};
+
+/**
  * Show or hide toolbar controls from the active slide pattern.
  *
  * @param {Object} fancybox Fancybox instance from event callbacks.
@@ -133,6 +161,7 @@ const syncPreviewToolbarButtons = ( fancybox ) => {
 	}
 
 	const pattern = getActivePreviewPattern();
+	const visibility = getPreviewToolbarButtonVisibility( pattern );
 
 	const setBtn = ( key, visible ) => {
 		const el = root.querySelector( `[data-dlxpw-toolbar="${ key }"]` );
@@ -140,28 +169,15 @@ const syncPreviewToolbarButtons = ( fancybox ) => {
 			return;
 		}
 		el.hidden = ! visible;
-		el.toggleAttribute( 'disabled', ! visible );
+		el.removeAttribute( 'disabled' );
 		el.setAttribute( 'aria-hidden', visible ? 'false' : 'true' );
 	};
 
-	setBtn(
-		'disable',
-		!! ( pattern && ! pattern.isLocal && ! pattern.isDisabled )
-	);
-	setBtn( 'delete', !! ( pattern && pattern.isLocal ) );
-	setBtn(
-		'edit',
-		!! ( pattern && pattern.isLocal )
-	);
-	setBtn( 'export', !! pattern );
-	setBtn(
-		'copy',
-		!! (
-			pattern &&
-			'string' === typeof pattern.content &&
-			pattern.content.trim()
-		)
-	);
+	setBtn( 'disable', visibility.disable );
+	setBtn( 'delete', visibility.delete );
+	setBtn( 'edit', visibility.edit );
+	setBtn( 'export', visibility.export );
+	setBtn( 'copy', visibility.copy );
 };
 
 /**
@@ -276,7 +292,7 @@ const getPatternPreviewFancyboxOptions = ( extra = {} ) => {
 		},
 		Carousel: {
 			Toolbar: {
-				absolute: true,
+				absolute: false,
 				enabled: true,
 				display: {
 					left: [ 'disablePattern', 'deletePattern' ],

--- a/src/js/react/views/patterns/components/ResponsiveIframe/index.js
+++ b/src/js/react/views/patterns/components/ResponsiveIframe/index.js
@@ -1,12 +1,119 @@
 import { useRef, useState, useEffect } from 'react';
 import { useResizeObserver } from '@wordpress/compose';
-import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import { __, _x } from '@wordpress/i18n';
 import ZoomIcon from '../Icons/ZoomIcon';
 import { ReactSpinner3 } from '@mediaron/react-spinners';
 import '@fancyapps/ui/dist/fancybox/fancybox.css';
-import '@fancyapps/ui/dist/fancybox/fancybox.sidebar.css';
 import { Fancybox } from '@fancyapps/ui/dist/fancybox/fancybox.js';
-import { Sidebar } from '@fancyapps/ui/dist/fancybox/fancybox.sidebar.js';
+import { canonicalPatternId, patternIdsEqual } from '../../utils/patternIdUtils';
+
+/** Patterns available for the open preview (single row or gallery). */
+let previewToolbarPatterns = [];
+
+/**
+ * @param {Array} patterns Pattern rows for toolbar resolution.
+ */
+const setPreviewToolbarPatterns = ( patterns ) => {
+	previewToolbarPatterns = Array.isArray( patterns ) ? patterns : [];
+};
+
+/**
+ * @param {string} src Preview iframe URL.
+ * @return {string|null} Raw `pattern_id` query value, or null.
+ */
+const parsePatternIdFromSlideSrc = ( src ) => {
+	if ( ! src || 'string' !== typeof src ) {
+		return null;
+	}
+	try {
+		const u = new URL( src, window.location.origin );
+		const raw = u.searchParams.get( 'pattern_id' );
+		return null !== raw && '' !== raw ? raw : null;
+	} catch ( e ) {
+		const match = src.match( /[?&]pattern_id=([^&]+)/ );
+		if ( ! match ) {
+			return null;
+		}
+		try {
+			return decodeURIComponent( match[ 1 ].replace( /\+/g, ' ' ) );
+		} catch ( err ) {
+			return match[ 1 ];
+		}
+	}
+};
+
+/**
+ * Resolves the pattern row for the current Fancybox slide preview URL.
+ *
+ * @return {Object|undefined} Matching pattern or undefined.
+ */
+const getActivePreviewPattern = () => {
+	const slide =
+		'function' === typeof Fancybox.getSlide ? Fancybox.getSlide() : null;
+	const raw = parsePatternIdFromSlideSrc( slide?.src );
+	if ( null === raw || '' === canonicalPatternId( raw ) ) {
+		return undefined;
+	}
+	return previewToolbarPatterns.find( ( p ) => patternIdsEqual( p.id, raw ) );
+};
+
+/**
+ * Dispatches a preview-toolbar custom event on document.
+ *
+ * @param {string}        name      Event name.
+ * @param {number|string} patternId Pattern post ID.
+ */
+const dispatchPreviewToolbarEvent = ( name, patternId ) => {
+	if ( '' === canonicalPatternId( patternId ) ) {
+		return;
+	}
+	document.dispatchEvent(
+		new CustomEvent( name, {
+			bubbles: true,
+			detail: { patternId },
+		} )
+	);
+};
+
+/**
+ * Show or hide toolbar controls from the active slide pattern.
+ *
+ * @param {Object} fancybox Fancybox instance from event callbacks.
+ */
+const syncPreviewToolbarButtons = ( fancybox ) => {
+	const root =
+		fancybox && 'function' === typeof fancybox.getContainer
+			? fancybox.getContainer()
+			: document.querySelector( '.fancybox__container' );
+	if ( ! root ) {
+		return;
+	}
+
+	const pattern = getActivePreviewPattern();
+
+	const setBtn = ( key, visible ) => {
+		const el = root.querySelector( `[data-dlxpw-toolbar="${ key }"]` );
+		if ( ! el ) {
+			return;
+		}
+		el.hidden = ! visible;
+		el.toggleAttribute( 'disabled', ! visible );
+		el.setAttribute( 'aria-hidden', visible ? 'false' : 'true' );
+	};
+
+	setBtn(
+		'disable',
+		!! ( pattern && ! pattern.isLocal && ! pattern.isDisabled )
+	);
+	setBtn( 'delete', !! ( pattern && pattern.isLocal ) );
+	setBtn(
+		'edit',
+		!! ( pattern && pattern.isLocal )
+	);
+	setBtn( 'export', !! pattern );
+	setBtn( 'copy', !! ( pattern && ! pattern.isLocal ) );
+};
 
 /**
  * Builds Fancybox instance options (second argument to Fancybox.show).
@@ -18,42 +125,119 @@ import { Sidebar } from '@fancyapps/ui/dist/fancybox/fancybox.sidebar.js';
  * @return {Object} Options for Fancybox.show.
  */
 const getPatternPreviewFancyboxOptions = ( extra = {} ) => {
-	const { Carousel: extraCarousel = {}, item, ...restExtra } = extra;
+	const { Carousel: extraCarousel = {}, ...restExtra } = extra;
 
-	const items = {};
-	if ( item?.isLocal ) {
-		items.deletePattern = {
+	const toolbarItems = {
+		disablePattern: {
 			tpl: `<button type="button" class="f-button" title="${ __(
+				'Disable pattern',
+				'pattern-wrangler'
+			) }" data-dlxpw-toolbar="disable" aria-label="${ __(
+				'Disable pattern',
+				'pattern-wrangler'
+			) }"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg></button>`,
+			click: () => {
+				const id = getActivePreviewPattern()?.id;
+				Fancybox.close();
+				dispatchPreviewToolbarEvent(
+					'dlxpw-pattern-preview-disable-request',
+					id
+				);
+			},
+		},
+		deletePattern: {
+			tpl: `<button type="button" class="f-button pattern-preview-fancybox-toolbar-btn--destructive" title="${ __(
 				'Delete pattern',
 				'pattern-wrangler'
-			) }" data-dlxpw-toolbar-delete aria-label="${ __(
+			) }" data-dlxpw-toolbar="delete" aria-label="${ __(
 				'Delete pattern',
 				'pattern-wrangler'
 			) }"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg></button>`,
 			click: () => {
+				const id = getActivePreviewPattern()?.id;
+				if ( '' === canonicalPatternId( id ) ) {
+					return;
+				}
 				Fancybox.close();
-				document.dispatchEvent(
-					new CustomEvent( 'dlxpw-pattern-preview-delete-request', {
-						bubbles: true,
-						detail: { patternId: item.id },
-					} )
+				dispatchPreviewToolbarEvent(
+					'dlxpw-pattern-preview-delete-request',
+					id
 				);
 			},
-		};
-	}
+		},
+		editPattern: {
+			tpl: `<button type="button" class="f-button" title="${ __(
+				'Edit pattern',
+				'pattern-wrangler'
+			) }" data-dlxpw-toolbar="edit" aria-label="${ __(
+				'Edit pattern',
+				'pattern-wrangler'
+			) }"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg></button>`,
+			click: () => {
+				const id = getActivePreviewPattern()?.id;
+				Fancybox.close();
+				dispatchPreviewToolbarEvent(
+					'dlxpw-pattern-preview-edit-request',
+					id
+				);
+			},
+		},
+		exportPattern: {
+			tpl: `<button type="button" class="f-button" title="${ _x(
+				'Export',
+				'Export pattern file',
+				'pattern-wrangler'
+			) }" data-dlxpw-toolbar="export" aria-label="${ _x(
+				'Export',
+				'Export pattern file',
+				'pattern-wrangler'
+			) }"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg></button>`,
+			click: () => {
+				const id = getActivePreviewPattern()?.id;
+				dispatchPreviewToolbarEvent(
+					'dlxpw-pattern-preview-export-request',
+					id
+				);
+			},
+		},
+		copyPattern: {
+			tpl: `<button type="button" class="f-button" title="${ __(
+				'Copy to New Pattern',
+				'pattern-wrangler'
+			) }" data-dlxpw-toolbar="copy" aria-label="${ __(
+				'Copy to New Pattern',
+				'pattern-wrangler'
+			) }"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button>`,
+			click: () => {
+				const id = getActivePreviewPattern()?.id;
+				dispatchPreviewToolbarEvent(
+					'dlxpw-pattern-preview-copy-request',
+					id
+				);
+			},
+		},
+	};
 
 	return {
 		closeButton: false,
+		on: {
+			ready: ( fb ) => {
+				syncPreviewToolbarButtons( fb );
+			},
+			'Carousel.change': ( fb ) => {
+				syncPreviewToolbarButtons( fb );
+			},
+		},
 		Carousel: {
 			Toolbar: {
 				absolute: true,
 				enabled: true,
 				display: {
-					left: [],
-					middle: [ 'deletePattern' ],
+					left: [ 'disablePattern', 'deletePattern' ],
+					middle: [ 'editPattern', 'exportPattern', 'copyPattern' ],
 					right: [ 'close' ],
 				},
-				items,
+				items: toolbarItems,
 			},
 			...extraCarousel,
 		},
@@ -64,7 +248,11 @@ const getPatternPreviewFancyboxOptions = ( extra = {} ) => {
 const buildPatternPreviewSlide = ( patternItem ) => {
 	const viewportWidth = patternItem.viewportWidth || 1200;
 	const previewUrl = patternItem?.id
-		? `${ ajaxurl }?action=dlxpw_pattern_preview&pattern_id=${ patternItem.id }&viewport_width=${ viewportWidth }`
+		? addQueryArgs( ajaxurl, {
+			action: 'dlxpw_pattern_preview',
+			pattern_id: patternItem.id,
+			viewport_width: viewportWidth,
+		} )
 		: '';
 
 	return {
@@ -75,6 +263,10 @@ const buildPatternPreviewSlide = ( patternItem ) => {
 };
 
 const popPatternPreview = ( item, galleryItems ) => {
+	const listForToolbar =
+		galleryItems && galleryItems.length >= 2 ? galleryItems : [ item ];
+	setPreviewToolbarPatterns( listForToolbar );
+
 	if ( ! galleryItems || galleryItems.length < 2 ) {
 		Fancybox.show(
 			[ buildPatternPreviewSlide( item ) ],
@@ -86,7 +278,9 @@ const popPatternPreview = ( item, galleryItems ) => {
 	const slides = galleryItems.map( ( patternItem ) =>
 		buildPatternPreviewSlide( patternItem )
 	);
-	let startIndex = galleryItems.findIndex( ( p ) => p.id === item.id );
+	let startIndex = galleryItems.findIndex( ( p ) =>
+		patternIdsEqual( p.id, item.id )
+	);
 	if ( startIndex < 0 ) {
 		startIndex = 0;
 	}
@@ -98,7 +292,6 @@ const popPatternPreview = ( item, galleryItems ) => {
 			Carousel: {
 				infinite: false,
 			},
-			item,
 		} )
 	);
 };

--- a/src/js/react/views/patterns/styles/patterns-view.scss
+++ b/src/js/react/views/patterns/styles/patterns-view.scss
@@ -43,14 +43,6 @@ body div.updated.warning {
 	z-index: 100000;
 }
 
-.fancybox__container .pattern-preview-fancybox-toolbar-btn--destructive {
-	color: #b32d2e;
-}
-
-.fancybox__container .pattern-preview-fancybox-toolbar-btn--destructive:hover {
-	color: #8a2424;
-}
-
 /* WordPress modals above Fancybox preview (z-index 100000) on patterns view. */
 .components-modal__screen-overlay,
 .components-modal__screen-container,

--- a/src/js/react/views/patterns/styles/patterns-view.scss
+++ b/src/js/react/views/patterns/styles/patterns-view.scss
@@ -41,6 +41,11 @@ body div.updated.warning {
 
 .fancybox__container {
 	z-index: 100000;
+
+	/* Fancybox .f-button can override [hidden] display; force toolbar slots off-screen when hidden. */
+	[data-dlxpw-toolbar][hidden] {
+		display: none !important;
+	}
 }
 
 /* WordPress modals above Fancybox preview (z-index 100000) on patterns view. */

--- a/src/js/react/views/patterns/styles/patterns-view.scss
+++ b/src/js/react/views/patterns/styles/patterns-view.scss
@@ -42,6 +42,22 @@ body div.updated.warning {
 .fancybox__container {
 	z-index: 100000;
 }
+
+.fancybox__container .pattern-preview-fancybox-toolbar-btn--destructive {
+	color: #b32d2e;
+}
+
+.fancybox__container .pattern-preview-fancybox-toolbar-btn--destructive:hover {
+	color: #8a2424;
+}
+
+/* WordPress modals above Fancybox preview (z-index 100000) on patterns view. */
+.components-modal__screen-overlay,
+.components-modal__screen-container,
+.components-modal__frame {
+	z-index: 100100;
+}
+
 .dlx-patterns-view-container {
 	padding: 24px 48px;
 

--- a/src/js/react/views/patterns/styles/patterns-view.scss
+++ b/src/js/react/views/patterns/styles/patterns-view.scss
@@ -307,6 +307,11 @@ dlx-patterns-view-filters-wrapper {
 .has-iframe .fancybox__content iframe {
 	overflow: scroll;
 }
+.f-caption {
+	font-size: 16px;
+	line-height: 1.5;
+	font-weight: 500;
+}
 
 
 // Pattern badge styles.

--- a/src/js/react/views/patterns/utils/patternIdUtils.js
+++ b/src/js/react/views/patterns/utils/patternIdUtils.js
@@ -1,0 +1,48 @@
+/**
+ * Pattern id helpers for the patterns view (local numeric IDs vs registered string slugs).
+ *
+ * Aligns with PHP `DLXPlugins\PatternWrangler\Functions::get_sanitized_pattern_id` character rules.
+ */
+
+/**
+ * Return a canonical value for strict equality checks, or '' if invalid.
+ *
+ * Positive integer post IDs normalize to a Number. Registered pattern names keep as string.
+ *
+ * @param {*} id Raw pattern id from REST, Fancybox URL, or events.
+ * @return {number|string} Canonical id, or '' when invalid.
+ */
+export function canonicalPatternId( id ) {
+	if ( null === id || undefined === id ) {
+		return '';
+	}
+	if ( 'number' === typeof id ) {
+		if ( Number.isFinite( id ) && id > 0 && Math.floor( id ) === id ) {
+			return id;
+		}
+		return '';
+	}
+	const s = String( id ).trim();
+	if ( '' === s ) {
+		return '';
+	}
+	if ( /^\d+$/.test( s ) ) {
+		const n = parseInt( s, 10 );
+		return Number.isFinite( n ) && n > 0 ? n : '';
+	}
+	if ( /^[a-zA-Z0-9/_-]+$/.test( s ) ) {
+		return s;
+	}
+	return '';
+}
+
+/**
+ * Whether two pattern ids refer to the same pattern (handles 123 vs "123" vs slug).
+ *
+ * @param {*} a First id.
+ * @param {*} b Second id.
+ * @return {boolean} True when both canonicalize to the same value and neither is invalid.
+ */
+export function patternIdsEqual( a, b ) {
+	return canonicalPatternId( a ) === canonicalPatternId( b );
+}

--- a/templates/pattern-preview.php
+++ b/templates/pattern-preview.php
@@ -260,8 +260,16 @@ if ( ! wp_is_block_theme() ) {
 		<?php wp_head(); ?>
 	</head>
 
-	<body <?php body_class(); ?> style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; display: relative; box-sizing: border-box; width: 100%; padding: 24px;">
-		<?php wp_body_open(); ?>
+	<?php
+	$can_overflow = true;
+	if ( isset( $_GET['iframe_preview'] ) && $_GET['iframe_preview'] ) {
+		$can_overflow = false;
+	}
+	?>
+	<body <?php body_class(); ?> style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; <?php echo ! $can_overflow ? 'overflow: hidden;' : ''; ?> display: relative; box-sizing: border-box; width: 100%; padding: 24px;">
+	<?php
+		wp_body_open();
+	?>
 		<div class="wp-site-blocks">
 			<header class="wp-block-template-part site-header">
 				<?php block_header_area(); ?>

--- a/templates/pattern-preview.php
+++ b/templates/pattern-preview.php
@@ -260,13 +260,13 @@ if ( ! wp_is_block_theme() ) {
 		<?php wp_head(); ?>
 	</head>
 
-	<body <?php body_class(); ?> style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; overflow: hidden; display: relative; box-sizing: border-box; width: 100%; padding: 24px;">
+	<body <?php body_class(); ?> style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; display: relative; box-sizing: border-box; width: 100%; padding: 24px;">
 		<?php wp_body_open(); ?>
 		<div class="wp-site-blocks">
 			<header class="wp-block-template-part site-header">
 				<?php block_header_area(); ?>
 			</header>
-			<div id="pattern-preview-content" class="pattern-preview-wrapper" style="max-width: 1400px; margin: 0 auto; aspect-ratio: 1/1;">
+			<div id="pattern-preview-content" class="pattern-preview-wrapper" style="max-width: 1400px; margin: 0 auto;">
 				<?php
 				if ( wp_is_block_theme() ) {
 					echo apply_filters( 'the_content', $blocks );


### PR DESCRIPTION
This release upgrades the Fancybox library to v6, bringing significant improvements to pattern previews and introducing new quick action capabilities:

*   **Fancybox Upgrade**: Updates the `@fancyapps/ui` package to v6.1.14, along with necessary adjustments to import paths and usage patterns.
*   **Enhanced Pattern Previews**:
    *   Introduces an interactive toolbar directly within the Fancybox lightbox, providing quick actions for patterns, including:
        *   Disabling/Enabling (for registered patterns)
        *   Deleting (for local patterns)
        *   Editing (for local patterns)
        *   Exporting to JSON
        *   Copying pattern block markup to the clipboard
    *   Enables a gallery view for patterns, allowing users to navigate between multiple pattern previews using a carousel.
    *   Resolves an issue with iframe preview scrolling within the lightbox for a smoother viewing experience.
    *   Adjusts the styling of Fancybox captions for improved readability.
*   **Code Refinements**:
    *   Adds new utility functions (`canonicalPatternId`, `patternIdsEqual`) to standardize pattern ID handling across local and registered patterns.
    *   Refactors components to utilize custom events for managing preview actions, enhancing modularity.
    *   Adjusts `z-index` values to ensure WordPress modals correctly overlay the Fancybox previews.
    *   Removes unused code and simplifies dependencies in various React components.