### PR TITLE
Adds default patterns view setting

### DIFF
--- a/php/Admin.php
+++ b/php/Admin.php
@@ -160,6 +160,12 @@ class Admin {
 		// Get array values.
 		$form_data = Functions::sanitize_array_recursive( $form_data );
 
+		if ( isset( $form_data['patternsDefaultView'] ) ) {
+			$patterns_default_view = Functions::sanitize_patterns_default_view_slug( $form_data['patternsDefaultView'] );
+			update_user_meta( get_current_user_id(), Functions::get_patterns_default_view_meta_key(), $patterns_default_view );
+			unset( $form_data['patternsDefaultView'] );
+		}
+
 		// Update options.
 		Options::update_options( $form_data );
 
@@ -203,6 +209,8 @@ class Admin {
 		// Pull in nonces to default options before returning.
 		$default_options['saveNonce']  = $options['saveNonce'];
 		$default_options['resetNonce'] = $options['resetNonce'];
+
+		$default_options['patternsDefaultView'] = Functions::get_patterns_default_view_slug_for_user( get_current_user_id() );
 
 		// Send success message.
 		wp_send_json_success(
@@ -609,6 +617,7 @@ class Admin {
 					'isUserNetworkAdmin'      => current_user_can( 'manage_network' ),
 					'canShowRatingsNag'       => Functions::can_show_ratings_nag(),
 					'dismissRatingsNagNonce'  => wp_create_nonce( 'dlx-pw-admin-dismiss-ratings-nag' ),
+					'patternsDefaultView'     => Functions::get_patterns_default_view_slug_for_user( get_current_user_id() ),
 				)
 			);
 			\wp_set_script_translations( 'dlx-pw-admin', 'pattern-wrangler' );
@@ -661,6 +670,7 @@ class Admin {
 					'doNotShowAgain'            => get_user_meta( get_current_user_id(), 'dlx_pw_do_not_show_again', true ) ?? false,
 					'syncedPatternPopupsActive' => Functions::is_activated( 'synced-pattern-popups/sppopups.php' ),
 					'syncedPatternPopupsUrl'    => esc_url_raw( admin_url( 'themes.php?page=simplest-popup-patterns' ) ),
+					'patternsDefaultView'       => Functions::get_patterns_default_view_slug_for_user( get_current_user_id() ),
 				)
 			);
 			\wp_set_script_translations( 'dlx-pw-patterns-view', 'pattern-wrangler' );

--- a/php/Functions.php
+++ b/php/Functions.php
@@ -877,4 +877,51 @@ class Functions {
 		}
 		return $highest_priority;
 	}
+
+	/**
+	 * User meta key for the Patterns Library default view preset (scoped per site).
+	 *
+	 * @return string Meta key.
+	 */
+	public static function get_patterns_default_view_meta_key() {
+		return sprintf( 'dlx_pw_patterns_default_view_%d', (int) get_current_blog_id() );
+	}
+
+	/**
+	 * Allowed slugs for Patterns Library default view presets.
+	 *
+	 * @return string[] Slugs.
+	 */
+	public static function get_allowed_patterns_default_view_slugs() {
+		return array( 'all', 'all_local', 'synced_local', 'unsynced_local', 'registered' );
+	}
+
+	/**
+	 * Sanitize a Patterns Library default view slug.
+	 *
+	 * @param string $slug Raw slug.
+	 * @return string Sanitized slug or `all`.
+	 */
+	public static function sanitize_patterns_default_view_slug( $slug ) {
+		$slug = sanitize_text_field( (string) $slug );
+		if ( in_array( $slug, self::get_allowed_patterns_default_view_slugs(), true ) ) {
+			return $slug;
+		}
+		return 'all';
+	}
+
+	/**
+	 * Get the Patterns Library default view slug for a user (current site).
+	 *
+	 * @param int $user_id User ID.
+	 * @return string Slug.
+	 */
+	public static function get_patterns_default_view_slug_for_user( $user_id ) {
+		$user_id = absint( $user_id );
+		if ( ! $user_id ) {
+			return 'all';
+		}
+		$stored = get_user_meta( $user_id, self::get_patterns_default_view_meta_key(), true );
+		return self::sanitize_patterns_default_view_slug( (string) $stored );
+	}
 }

--- a/src/js/react/views/main/main.js
+++ b/src/js/react/views/main/main.js
@@ -23,39 +23,37 @@ const Main = () => {
 	const data = dlxPatternWranglerAdmin.options;
 	const networkOptions = dlxPatternWranglerAdmin.networkOptions;
 
-	const [ showRatingsNag, setShowRatingsNag ] = useState( dlxPatternWranglerAdmin.canShowRatingsNag );
+	const [ showRatingsNag, setShowRatingsNag ] = useState(
+		dlxPatternWranglerAdmin.canShowRatingsNag
+	);
 
-	const {
-		control,
-		handleSubmit,
-		getValues,
-		reset,
-		setError,
-		trigger,
-	} = useForm( {
-		defaultValues: {
-			hideAllPatterns: data.hideAllPatterns,
-			hideCorePatterns: data.hideCorePatterns,
-			hidePatternsMenu: data.hidePatternsMenu,
-			hideRemotePatterns: data.hideRemotePatterns,
-			hideCoreSyncedPatterns: data.hideCoreSyncedPatterns,
-			hideCoreUnsyncedPatterns: data.hideCoreUnsyncedPatterns,
-			disablePatternImporterBlock: data.disablePatternImporterBlock,
-			allowFrontendPatternPreview: data.allowFrontendPatternPreview,
-			hideUncategorizedPatterns: data.hideUncategorizedPatterns,
-			showCustomizerUI: data.showCustomizerUI,
-			loadCustomizerCSSBlockEditor: data.loadCustomizerCSSBlockEditor,
-			loadCustomizerCSSFrontend: data.loadCustomizerCSSFrontend,
-			hideThemePatterns: data.hideThemePatterns,
-			hidePluginPatterns: data.hidePluginPatterns,
-			enableEnhancedView: data.enableEnhancedView,
-			showMenusUI: data.showMenusUI,
-			makePatternsExportable: data.makePatternsExportable,
-			patternWranglerMenuLocation: data.patternWranglerMenuLocation,
-			saveNonce: dlxPatternWranglerAdmin.saveNonce,
-			resetNonce: dlxPatternWranglerAdmin.resetNonce,
-		},
-	} );
+	const { control, handleSubmit, getValues, reset, setError, trigger } =
+		useForm( {
+			defaultValues: {
+				hideAllPatterns: data.hideAllPatterns,
+				hideCorePatterns: data.hideCorePatterns,
+				hidePatternsMenu: data.hidePatternsMenu,
+				hideRemotePatterns: data.hideRemotePatterns,
+				hideCoreSyncedPatterns: data.hideCoreSyncedPatterns,
+				hideCoreUnsyncedPatterns: data.hideCoreUnsyncedPatterns,
+				disablePatternImporterBlock: data.disablePatternImporterBlock,
+				allowFrontendPatternPreview: data.allowFrontendPatternPreview,
+				hideUncategorizedPatterns: data.hideUncategorizedPatterns,
+				showCustomizerUI: data.showCustomizerUI,
+				loadCustomizerCSSBlockEditor: data.loadCustomizerCSSBlockEditor,
+				loadCustomizerCSSFrontend: data.loadCustomizerCSSFrontend,
+				hideThemePatterns: data.hideThemePatterns,
+				hidePluginPatterns: data.hidePluginPatterns,
+				enableEnhancedView: data.enableEnhancedView,
+				showMenusUI: data.showMenusUI,
+				makePatternsExportable: data.makePatternsExportable,
+				patternWranglerMenuLocation: data.patternWranglerMenuLocation,
+				patternsDefaultView:
+					dlxPatternWranglerAdmin.patternsDefaultView || 'all',
+				saveNonce: dlxPatternWranglerAdmin.saveNonce,
+				resetNonce: dlxPatternWranglerAdmin.resetNonce,
+			},
+		} );
 	const formValues = useWatch( { control } );
 	const { errors, isDirty, dirtyFields } = useFormState( {
 		control,
@@ -67,8 +65,7 @@ const Main = () => {
 	const dismissRatingsNag = async() => {
 		SendCommand( 'dlx_pw_dismiss_ratings_nag', {
 			nonce: dlxPatternWranglerAdmin.dismissRatingsNagNonce,
-		} ).then( () => {
-		} );
+		} ).then( () => {} );
 	};
 
 	/**
@@ -412,9 +409,7 @@ const Main = () => {
 	 */
 	const getShowPatternsImporterBlock = () => {
 		const patternsBlockData = {
-			canUseBlock: ! getValues(
-				'disablePatternImporterBlock'
-			),
+			canUseBlock: ! getValues( 'disablePatternImporterBlock' ),
 			networkCanUseBlock: true,
 		};
 		if ( dlxPatternWranglerAdmin.isMultisite ) {
@@ -438,9 +433,7 @@ const Main = () => {
 				);
 			}
 		} else {
-			patternsBlockData.canUseBlock = getValues(
-				'disablePatternImporterBlock'
-			);
+			patternsBlockData.canUseBlock = getValues( 'disablePatternImporterBlock' );
 			patternsBlockData.networkCanUseBlock = true;
 		}
 		return (
@@ -509,10 +502,7 @@ const Main = () => {
 					control={ control }
 					render={ ( { field: { onChange, value } } ) => (
 						<ToggleControl
-							label={ __(
-								'Hide Theme Patterns',
-								'pattern-wrangler'
-							) }
+							label={ __( 'Hide Theme Patterns', 'pattern-wrangler' ) }
 							checked={ value || 'default' === value }
 							disabled={ ! themePatternData.networkCanShow }
 							onChange={ ( boolValue ) => {
@@ -565,10 +555,7 @@ const Main = () => {
 					control={ control }
 					render={ ( { field: { onChange, value } } ) => (
 						<ToggleControl
-							label={ __(
-								'Hide Plugin Patterns',
-								'pattern-wrangler'
-							) }
+							label={ __( 'Hide Plugin Patterns', 'pattern-wrangler' ) }
 							checked={ value || 'default' === 'value' }
 							disabled={ ! pluginPatternData.networkCanShow }
 							onChange={ ( boolValue ) => {
@@ -609,7 +596,10 @@ const Main = () => {
 			networkAllPatternsDisabled: false,
 		};
 		if ( dlxPatternWranglerAdmin.isMultisite ) {
-			if ( networkOptions.patternConfiguration === 'disabled' || 'hide' === networkOptions.hideAllPatterns ) {
+			if (
+				networkOptions.patternConfiguration === 'disabled' ||
+				'hide' === networkOptions.hideAllPatterns
+			) {
 				hideAllPatternsData.allPatternsDisabled = true;
 				hideAllPatternsData.networkAllPatternsDisabled = true;
 			} else if ( 'show' === networkOptions.hideAllPatterns ) {
@@ -685,7 +675,10 @@ const Main = () => {
 							dismissRatingsNag();
 						} }
 					>
-						{ __( 'Thank you for using Pattern Wrangler! Please show your support by leaving a kind review on WordPress.org.', 'pattern-wrangler' ) }
+						{ __(
+							'Thank you for using Pattern Wrangler! Please show your support by leaving a kind review on WordPress.org.',
+							'pattern-wrangler'
+						) }
 						<div className="dlx-admin-component-row-button buttons-ratings-nag">
 							<Button
 								variant="secondary"
@@ -763,6 +756,65 @@ const Main = () => {
 												) }
 											/>
 										) }
+									/>
+								</td>
+							</tr>
+							<tr>
+								<th scope="row">
+									{ __( 'Default Patterns View', 'pattern-wrangler' ) }
+								</th>
+								<td>
+									<Controller
+										name="patternsDefaultView"
+										control={ control }
+										render={ ( { field: { onChange, value } } ) => {
+											return (
+												<SelectControl
+													label={ __(
+														'Default filter when opening the Pattern Library',
+														'pattern-wrangler'
+													) }
+													hideLabelFromVision={ true }
+													value={ value }
+													options={ [
+														{
+															label: __( 'All Patterns', 'pattern-wrangler' ),
+															value: 'all',
+														},
+														{
+															label: __(
+																'All Local Patterns',
+																'pattern-wrangler'
+															),
+															value: 'all_local',
+														},
+														{
+															label: __( 'Synced Patterns', 'pattern-wrangler' ),
+															value: 'synced_local',
+														},
+														{
+															label: __(
+																'Unsynced Patterns',
+																'pattern-wrangler'
+															),
+															value: 'unsynced_local',
+														},
+														{
+															label: __(
+																'Registered Patterns',
+																'pattern-wrangler'
+															),
+															value: 'registered',
+														},
+													] }
+													onChange={ onChange }
+													help={ __(
+														'Your personal default when the library URL has no filter parameters.',
+														'pattern-wrangler'
+													) }
+												/>
+											);
+										} }
 									/>
 								</td>
 							</tr>
@@ -972,17 +1024,31 @@ const Main = () => {
 											control={ control }
 											render={ ( { field: { onChange, value } } ) => (
 												<SelectControl
-													label={ __( 'Pattern Wrangler Menu Location', 'pattern-wrangler' ) }
+													label={ __(
+														'Pattern Wrangler Menu Location',
+														'pattern-wrangler'
+													) }
 													value={ value }
 													onChange={ ( newValue ) => {
 														onChange( newValue );
 													} }
-													disabled={ getValues( 'hidePatternsMenu' ) && getValues( 'hideAllPatterns' ) }
+													disabled={
+														getValues( 'hidePatternsMenu' ) &&
+														getValues( 'hideAllPatterns' )
+													}
 												>
-													<option value="above_media">{ __( 'Above Media', 'pattern-wrangler' ) }</option>
-													<option value="below_appearance">{ __( 'Below Appearance', 'pattern-wrangler' ) }</option>
-													<option value="below_settings">{ __( 'Below Settings', 'pattern-wrangler' ) }</option>
-													<option value="in_appearance">{ __( 'In Appearance', 'pattern-wrangler' ) }</option>
+													<option value="above_media">
+														{ __( 'Above Media', 'pattern-wrangler' ) }
+													</option>
+													<option value="below_appearance">
+														{ __( 'Below Appearance', 'pattern-wrangler' ) }
+													</option>
+													<option value="below_settings">
+														{ __( 'Below Settings', 'pattern-wrangler' ) }
+													</option>
+													<option value="in_appearance">
+														{ __( 'In Appearance', 'pattern-wrangler' ) }
+													</option>
 												</SelectControl>
 											) }
 										/>

--- a/src/js/react/views/patterns/components/PatternsGrid.js
+++ b/src/js/react/views/patterns/components/PatternsGrid.js
@@ -40,6 +40,10 @@ import patternsStore from '../store';
 import createPatternFromFile from '../utils/createPatternFromFile';
 import ResponsiveIframe from './ResponsiveIframe';
 import { canonicalPatternId, patternIdsEqual } from '../utils/patternIdUtils';
+import {
+	mergePresetIntoQueryArgs,
+	urlHasExplicitPatternFilters,
+} from '../utils/patternsDefaultViewPresets';
 
 const defaultLayouts = {
 	grid: {
@@ -470,7 +474,13 @@ const Interface = ( props ) => {
 	 * @return {Object} The default view.
 	 */
 	const getDefaultView = () => {
-		const queryArgs = getQueryArgs( window.location.href );
+		const rawQueryArgs = getQueryArgs( window.location.href );
+		const presetSlug =
+			typeof dlxEnhancedPatternsView !== 'undefined' &&
+			dlxEnhancedPatternsView.patternsDefaultView
+				? dlxEnhancedPatternsView.patternsDefaultView
+				: 'all';
+		const queryArgs = mergePresetIntoQueryArgs( rawQueryArgs, presetSlug );
 		const normalizedStatusFilters = getNormalizedStatusFilters( queryArgs );
 
 		return {
@@ -1682,6 +1692,24 @@ const Interface = ( props ) => {
 		// Update the view state.
 		//setView( newView );
 	};
+
+	useEffect( () => {
+		const raw = getQueryArgs( window.location.href );
+		if ( urlHasExplicitPatternFilters( raw ) ) {
+			return;
+		}
+		const slug =
+			typeof dlxEnhancedPatternsView !== 'undefined' &&
+			dlxEnhancedPatternsView.patternsDefaultView
+				? dlxEnhancedPatternsView.patternsDefaultView
+				: 'all';
+		if ( 'all' === slug ) {
+			return;
+		}
+		onChangeView( getDefaultView() );
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- One-time URL sync for user preset.
+	}, [] );
+
 	useEffect( () => {
 		resetPreviewQueue( patternsDisplay );
 	}, [ patternsDisplay ] );

--- a/src/js/react/views/patterns/utils/patternsDefaultViewPresets.js
+++ b/src/js/react/views/patterns/utils/patternsDefaultViewPresets.js
@@ -1,0 +1,68 @@
+/**
+ * Patterns Library default view presets (user meta) merged into URL query args.
+ */
+
+export const PATTERN_FILTER_QUERY_KEYS = [
+	'patternType',
+	'patternStatus',
+	'patternLocalStatus',
+	'patternRegisteredStatus',
+	'patternLocalRegisteredStatus',
+];
+
+/**
+ * Whether the URL already specifies at least one pattern filter param.
+ *
+ * @param {Object} queryArgs Parsed query args.
+ * @return {boolean} True if explicit.
+ */
+export function urlHasExplicitPatternFilters( queryArgs ) {
+	if ( ! queryArgs || typeof queryArgs !== 'object' ) {
+		return false;
+	}
+	return PATTERN_FILTER_QUERY_KEYS.some( ( key ) =>
+		Object.prototype.hasOwnProperty.call( queryArgs, key )
+	);
+}
+
+/**
+ * Apply a saved preset slug when the URL has no explicit pattern filter keys.
+ *
+ * @param {Object} queryArgs Parsed query args from the current URL.
+ * @param {string} slug      Preset slug from localized script.
+ * @return {Object} Query args for getNormalizedStatusFilters.
+ */
+export function mergePresetIntoQueryArgs( queryArgs, slug ) {
+	const base = { ...queryArgs };
+
+	if ( urlHasExplicitPatternFilters( base ) ) {
+		return base;
+	}
+
+	switch ( slug ) {
+		case 'all_local':
+			base.patternType = 'local';
+			base.patternStatus = 'both';
+			base.patternLocalStatus = 'published';
+			break;
+		case 'synced_local':
+			base.patternType = 'local';
+			base.patternStatus = 'synced';
+			base.patternLocalStatus = 'published';
+			break;
+		case 'unsynced_local':
+			base.patternType = 'local';
+			base.patternStatus = 'unsynced';
+			base.patternLocalStatus = 'published';
+			break;
+		case 'registered':
+			base.patternType = 'registered';
+			base.patternRegisteredStatus = 'unpaused';
+			break;
+		case 'all':
+		default:
+			break;
+	}
+
+	return base;
+}

--- a/src/scss/admin.scss
+++ b/src/scss/admin.scss
@@ -74,21 +74,23 @@
 		margin: 0 auto;
 		padding: 2.4em 20px;
 	}
+
 	.dlx-pw-body__content {
 		padding: 10px 35px;
 		background: #f0f0f1;
 		border: 1px solid #c3c4c7;
 		border-top: 0;
-		box-shadow: 0 1px 6px rgba(0,0,0,.08);
+		box-shadow: 0 1px 6px rgba(0, 0, 0, .08);
 		padding-bottom: 35px;
 		margin-bottom: 40px;
 	}
 }
+
 .dlx-pw-admin-buttons {
 	display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding-top: 25px;
+	justify-content: space-between;
+	align-items: center;
+	padding-top: 25px;
 }
 
 /* Button styles stolen from QuotesDLX */
@@ -119,15 +121,19 @@
 	&.center {
 		display: flex;
 	}
+
 	&.left {
 		justify-content: flex-start;
 	}
+
 	&.center {
 		justify-content: center;
 	}
+
 	&.right {
 		justify-content: flex-end;
 	}
+
 	button,
 	.has__btn-primary {
 		width: 100%;
@@ -153,6 +159,7 @@
 			transition: all 0.4s ease-in-out;
 		}
 	}
+
 	.has__btn-primary {
 		display: block;
 		width: 100%;
@@ -177,7 +184,7 @@ html {
 svg.lucide {
 	color: inherit;
 	fill: none !important;
-	
+
 	path,
 	circle,
 	rect,
@@ -201,12 +208,14 @@ svg.lucide {
 		padding-top: 20px;
 	}
 }
+
 .form-table td {
 	padding-top: 20px;
 	padding-bottom: 20px;
 }
 
 .form-table {
+
 	input[type="text"],
 	select {
 		display: block;
@@ -215,9 +224,11 @@ svg.lucide {
 
 	.dlx-admin__row {
 		margin-bottom: 20px;
+
 		&:last-child {
 			margin-bottom: 0;
 		}
+
 		max-width: 600px !important;
 
 		&.dlx-admin__row-full-width {
@@ -232,50 +243,63 @@ svg.lucide {
 			button {
 				box-shadow: unset !important;
 			}
+
 			&.is-opened {
 				.components-panel__body-title button {
-					box-shadow: unset !important; /* override core style */
+					box-shadow: unset !important;
+					/* override core style */
 					border-bottom: 1px solid #ddd;
 				}
+
 				thead tr {
 					border-bottom: 1px solid #333;
 				}
+
 				thead th {
 					padding-left: 10px;
 				}
 			}
 		}
 	}
-	
+
 	.components-toggle-control__label,
 	.components-base-control__label,
 	.components-input-control__label {
-		font-weight: 600 !important; /* override core style */
-		text-transform: capitalize !important; /* override core style */
-		font-size: 14px !important; /* override core style */
+		font-weight: 600 !important;
+		/* override core style */
+		text-transform: capitalize !important;
+		/* override core style */
+		font-size: 14px !important;
+		/* override core style */
 	}
 }
 
 .dlx-pw-admin-buttons button {
 	margin-right: 20px;
+
 	&:last-child {
 		margin-right: 0;
 	}
+
 	&:disabled {
 		opacity: 0.5;
 	}
+
 	&.is-primary,
 	&:disabled {
-		background: #2271b1 !important; /* override core style */
+		background: #2271b1 !important;
+		/* override core style */
 		padding-left: 15px;
 		padding-right: 15px;
 
-		&:hover:not(:disabled)  {
-			background: #135e96 !important; /* override core style */
+		&:hover:not(:disabled) {
+			background: #135e96 !important;
+			/* override core style */
 		}
 	}
+
 	&.is-saving,
-	&.is-resetting{
+	&.is-resetting {
 		svg {
 			animation: dlx-pw-rotate;
 			animation-duration: 1.2s;
@@ -283,6 +307,7 @@ svg.lucide {
 			animation-timing-function: linear;
 		}
 	}
+
 	svg {
 		fill: none;
 		color: currentColor;
@@ -298,38 +323,45 @@ svg.lucide {
 		margin-bottom: 12px;
 	}
 }
+
 .dlx-category-row__label {
 	flex: 1;
 }
+
 .dlx-category-row {
 	display: flex;
 	justify-content: flex-start;
 	align-items: baseline;
 	column-gap: 20px;
 }
+
 .dlx-category-row__label-text {
 	font-size: 1.2em;
 	font-weight: 600;
 }
+
 .dlx-category-row__slug {
 	margin-top: 4px;
 	font-size: 13px;
 	color: #666;
 }
+
 .dlx-category-row__count {
 	margin-top: 4px;
 	font-size: 13px;
 	color: #666;
 	font-style: italic;
 }
+
 .dlx-category-popover {
 	padding: 20px;
 	min-width: 175px;
 }
+
 /**
  * Snackbar styles.
  */
- .dlx-pw-snackbar.components-snackbar {
+.dlx-pw-snackbar.components-snackbar {
 	position: fixed;
 	top: 32px;
 	right: 0;
@@ -341,6 +373,7 @@ svg.lucide {
 		display: flex;
 		align-items: center;
 	}
+
 	.components-snackbar__icon {
 		position: absolute;
 		top: 24px;
@@ -350,6 +383,7 @@ svg.lucide {
 		bottom: auto;
 		line-height: 0;
 	}
+
 	.components-snackbar__content-with-icon {
 		padding-left: 50px;
 	}
@@ -362,22 +396,25 @@ svg.lucide {
 			animation-timing-function: linear;
 		}
 	}
+
 	&.dlx-pw-snackbar-success {
 		background: #14720D;
 		color: #FFF;
 	}
+
 	&.dlx-pw-snackbar-error,
 	&.dlx-pw-snackbar-critical {
 		background: #820000;
 		color: #FFF;
 	}
+
 	&.dlx-pw-snackbar-warning {
 		background: #FFC107;
 		color: #000;
 	}
- }
+}
 
- :root {
+:root {
 	--dlx-pw-admin--color-notice--info: #e3f3f7;
 	--dlx-pw-admin--color-notice--info-alt: #3a8dc4;
 	--dlx-pw-admin--color-notice--success: #eaf5ea;
@@ -452,9 +489,11 @@ svg.lucide {
 		.components-notice {
 			border-left-color: var(--dlx-pw-admin--color-notice--error-alt);
 		}
+
 		svg {
 			color: var(--dlx-pw-admin--color-notice--error-alt);
 		}
+
 		svg path {
 			fill: var(--dlx-pw-admin--color-notice--error-alt);
 		}
@@ -472,6 +511,7 @@ svg.lucide {
 			margin-left: 15px;
 			margin-right: 8px;
 		}
+
 		.components-notice__content {
 			padding: 8px 15px 8px 0;
 		}
@@ -513,6 +553,7 @@ svg.lucide {
 			svg:not(.lucide) path {
 				fill: var(--dlx-pw-admin--color-notice--info-alt);
 			}
+
 			svg.lucide {
 				color: var(--dlx-pw-admin--color-notice--info-alt);
 			}
@@ -533,6 +574,7 @@ svg.lucide {
 		svg:not(.lucide) path {
 			fill: var(--dlx-pw-admin--color-notice--warning-alt);
 		}
+
 		svg.lucide {
 			color: var(--dlx-pw-admin--color-notice--warning-alt);
 		}
@@ -555,6 +597,7 @@ svg.lucide {
 				display: inline-block;
 			}
 		}
+
 		&.is-required label:after {
 			position: absolute;
 			display: inline-block;
@@ -613,7 +656,7 @@ svg.lucide {
 			padding: 0;
 
 			&:hover {
-				& ~ label {
+				&~label {
 					svg path {
 						fill: none;
 						color: currentColor;
@@ -692,23 +735,24 @@ svg.lucide {
 
 #dlx-pw-license-show-hide {
 	&:hover {
-		& ~ label {
+		&~label {
 			svg path {
 				fill: currentColor;
 			}
 		}
 	}
 }
+
 .dlx-admin__license--input-wrapper {
 	&:hover {
-		& ~ label {
+		&~label {
 			svg path {
 				fill: none;
 				color: currentColor;
 			}
 		}
 	}
-	
+
 }
 
 .components-button.button-reset.has-icon {
@@ -720,6 +764,7 @@ svg.lucide {
 	.is-required label {
 		position: relative;
 	}
+
 	.is-required label:after {
 		position: absolute;
 		display: inline-block;
@@ -733,7 +778,7 @@ svg.lucide {
 	}
 }
 
-button.dlx-gbhacks__btn-danger  {
+button.dlx-gbhacks__btn-danger {
 	background: #fff;
 	color: #822700;
 	border-color: #822700;
@@ -744,13 +789,16 @@ button.dlx-gbhacks__btn-danger  {
 		border-color: #822700;
 	}
 }
+
 div.can-revoke {
 	justify-content: flex-end;
 }
-.dlx-admin__license--wrapper  {
+
+.dlx-admin__license--wrapper {
 	.dlx-gbhacks__btn-danger {
 		text-align: right;
 	}
+
 	.dlx-admin__tabs--content-actions {
 		padding-top: 0;
 	}
@@ -804,6 +852,7 @@ div.can-revoke {
 		transition: all 0.4s ease-in-out;
 		border-width: 1px;
 		margin-right: 12px;
+
 		&:last-child {
 			margin-right: 0;
 		}
@@ -821,7 +870,8 @@ div.can-revoke {
 
 		&.has-error {
 			border: 1px solid #bc2b2c;
-			box-shadow: none !important; /* override core style */
+			box-shadow: none !important;
+			/* override core style */
 
 			&:hover {
 				cursor: not-allowed;
@@ -875,6 +925,7 @@ div.can-revoke {
 				border-color: #822700;
 			}
 		}
+
 		&.dlx__btn-rating {
 			background: #ff00f7;
 			color: #FFF;
@@ -967,11 +1018,13 @@ div.can-revoke {
 		}
 	}
 }
+
 .dlx-info-text {
 	font-size: 16px;
 	line-height: 1.3;
 }
-.dlx-admin-panel-area > h2 ~ p {
+
+.dlx-admin-panel-area>h2~p {
 	font-size: 16px;
 	line-height: 1.3;
 }
@@ -982,8 +1035,10 @@ div.can-revoke {
 	max-width: 600px;
 	margin: 0 auto;
 }
+
 .fancybox__container {
-	z-index: 9999; /* so we're over the admin menus */
+	z-index: 9999;
+	/* so we're over the admin menus */
 }
 
 .dlx-table-row-categories {
@@ -995,10 +1050,11 @@ div.can-revoke {
 /**
  * Site Picker.
  */
- /* Url Wrapper Input */
+/* Url Wrapper Input */
 .pw-pub-url-input__suggestion-table {
 	thead {
 		background: #DDDDDD;
+
 		th {
 			padding: 10px 10px;
 			font-weight: 600;
@@ -1007,11 +1063,13 @@ div.can-revoke {
 
 		}
 	}
+
 	tbody td {
 		padding: 10px 10px;
 		margin: 0;
 		vertical-align: middle;
 		border-bottom: 1px solid #ddd;
+
 		a.components-button.has-icon.has-text.is-link {
 			margin-left: 0;
 			padding-left: 0;
@@ -1019,11 +1077,13 @@ div.can-revoke {
 		}
 	}
 }
+
 .pw-pub-url-input__suggestion-actions {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
 }
+
 .pw-url-input__suggestions-close-wrapper {
 	display: flex;
 	justify-content: space-between;
@@ -1045,6 +1105,7 @@ div.can-revoke {
 		border-color: #FFF;
 		box-shadow: inset 0 0 0 1px #DDD;
 		padding: 10 15px;
+
 		&:hover {
 			background: #FFF;
 			color: #999;
@@ -1052,12 +1113,14 @@ div.can-revoke {
 		}
 	}
 }
- .pw-url-input {
+
+.pw-url-input {
 	display: inline-block;
 	max-width: 520px;
 	width: 100%;
 	flex-wrap: wrap;
 	position: relative;
+
 	.components-base-control {
 		.components-base-control__label {
 			font-size: 16px;
@@ -1065,6 +1128,7 @@ div.can-revoke {
 			width: 100%;
 		}
 	}
+
 	.pw-suggestions-wrapper {
 		width: 100%;
 		position: relative;
@@ -1072,6 +1136,7 @@ div.can-revoke {
 		left: 0;
 		max-height: 250px;
 		overflow-y: auto;
+
 		.pw-url-input__suggestion {
 			position: relative;
 			border: 1px solid #ddd;
@@ -1092,6 +1157,7 @@ div.can-revoke {
 				height: 24px;
 				top: calc(50% - 8px);
 				left: 10px;
+
 				path {
 					fill: unset;
 				}
@@ -1099,12 +1165,12 @@ div.can-revoke {
 
 			&:hover {
 				background: #f1f1f1;
-				border-color: var( --wp-admin-theme-color );
+				border-color: var(--wp-admin-theme-color);
 			}
 
 			&.is-selected {
 				background: #f1f1f1;
-				border-color: var( --wp-admin-theme-color );
+				border-color: var(--wp-admin-theme-color);
 			}
 
 			.pw-search-item {
@@ -1113,14 +1179,16 @@ div.can-revoke {
 				white-space: pre-wrap;
 				overflow-wrap: break-word;
 			}
+
 			.pw-search-item-title {
 				display: block;
 				margin-bottom: 0.2em;
 				font-weight: 500;
 				position: relative;
 				overflow: hidden;
-   				text-overflow: ellipsis;
+				text-overflow: ellipsis;
 			}
+
 			.pw-search-item-info {
 				word-break: break-all;
 				display: block;
@@ -1131,6 +1199,7 @@ div.can-revoke {
 		}
 	}
 }
+
 .pw-pub-url-search-wrapper {
 	position: relative;
 
@@ -1139,23 +1208,25 @@ div.can-revoke {
 		right: 0;
 		top: calc(50% - 18px);
 	}
+
 	.pw-pub-url-input__apply-button.components-button {
 		position: absolute;
 		right: 0;
 		top: calc(50% - 18px);
 	}
 }
+
 .pw-pub-url-input__wrapper {
-	
+
 	label {
 		display: block;
 		width: 100%;
 		font-weight: 600;
 		margin-bottom: 5px;
 	}
-	.pw-pub-url-input__suggestion {
-		
-	}
+
+	.pw-pub-url-input__suggestion {}
+
 	.pw-pub-url-input__input-wrapper {
 		position: relative;
 		display: grid;
@@ -1163,6 +1234,7 @@ div.can-revoke {
 		grid-gap: 10px;
 		width: 100%;
 		margin-bottom: 10px;
+
 		input[type="text"] {
 			border: 1px solid #ddd;
 			border-radius: 3px;
@@ -1171,9 +1243,11 @@ div.can-revoke {
 			width: 100%;
 			margin: 0;
 		}
+
 		.pw-pub-url-input__input {
 			line-height: 1;
 		}
+
 		.components-spinner {
 			position: absolute;
 			right: 14px;
@@ -1181,7 +1255,8 @@ div.can-revoke {
 			top: calc(50% - 12px);
 			margin: 0;
 		}
-		.pw-pub-url-input__input ~ .components-button {
+
+		.pw-pub-url-input__input~.components-button {
 			box-shadow: unset;
 			border: unset;
 			background: unset;
@@ -1189,7 +1264,7 @@ div.can-revoke {
 	}
 }
 
-.pw-pub-url-input__input ~ .components-button,
+.pw-pub-url-input__input~.components-button,
 .pw-pub-url-input__suggestion-item .components-button {
 	position: relative;
 
@@ -1210,3 +1285,6 @@ div.can-revoke {
 	}
 }
 
+.components-toggle-group-control {
+	border: 1px solid #ccc;
+}


### PR DESCRIPTION
Introduces a new user-specific setting to define the default filter for the Patterns Library.

This enhancement allows users to:
- Set their preferred initial view (e.g., "All Local Patterns", "Synced Patterns") when accessing the Patterns Library without specific URL filters.
- Improve their workflow by automatically applying a chosen filter, making it quicker to find relevant patterns.

The changes involve:
- Adding a new UI control in the admin settings for users to select their default view.
- Storing and retrieving this preference via site-scoped user meta.
- Implementing logic to dynamically apply the saved default view to the Patterns Library when no explicit filters are present in the URL.
- Introducing utility functions to manage allowed view slugs, sanitize inputs, and merge view presets into query arguments.