### PR TITLE
Adds option to disable pattern revisions

### DIFF
--- a/php/Functions.php
+++ b/php/Functions.php
@@ -340,6 +340,24 @@ class Functions {
 	}
 
 	/**
+	 * Whether revisions should be disabled for the wp_block post type.
+	 *
+	 * Network option applies when the plugin is network-activated (Functions::is_multisite).
+	 *
+	 * @return bool True if revisions are disabled.
+	 */
+	public static function are_pattern_revisions_disabled() {
+		$options     = Options::get_options();
+		$site_off    = (bool) ( $options['disablePatternRevisions'] ?? false );
+		$network_off = false;
+		if ( self::is_multisite( false ) ) {
+			$network     = Options::get_network_options();
+			$network_off = (bool) ( $network['disablePatternRevisionsForNetwork'] ?? false );
+		}
+		return $site_off || $network_off;
+	}
+
+	/**
 	 * Check if core patterns are enabled for the current site.
 	 *
 	 * @param int $site_id The site ID.

--- a/php/Options.php
+++ b/php/Options.php
@@ -80,6 +80,7 @@ class Options {
 				case 'loadCustomizerCSSFrontend':
 				case 'makePatternsExportable':
 				case 'enableEnhancedView':
+				case 'disablePatternRevisions':
 					$option = filter_var( $options[ $key ], FILTER_VALIDATE_BOOLEAN );
 					break;
 				default:
@@ -112,6 +113,7 @@ class Options {
 			switch ( $key ) {
 				case 'disablePatternImporterBlock':
 				case 'disablePatternExporterForNetwork':
+				case 'disablePatternRevisionsForNetwork':
 				case 'enableEnhancedView':
 					$option = filter_var( $options[ $key ], FILTER_VALIDATE_BOOLEAN );
 					break;
@@ -217,6 +219,7 @@ class Options {
 			'loadCustomizerCSSBlockEditor' => false,
 			'loadCustomizerCSSFrontend'    => true,
 			'makePatternsExportable'       => false,
+			'disablePatternRevisions'      => false,
 			'enableEnhancedView'           => true,
 			'patternWranglerMenuLocation'  => 'above_media', /* Can be above_media, below_appearance, below_settings, in_appearance. */
 		);
@@ -238,19 +241,20 @@ class Options {
 	 */
 	public static function get_network_defaults() {
 		$defaults = array(
-			'patternMothershipSiteId'          => 1,
-			'patternConfiguration'             => 'hybrid', // Can be `nework_only`, `local_only`, `hybrid`, or `disabled`.
-			'hideSyncedPatternsForNetwork'     => 'default', // If patternConfiguration is `hybrid`, site-admins can still show/hide synced local and network patterns. If `local_only`, site-admins can only show/hide local patterns. IF `network_only`, site-admins will not see a synced patterns option.
-			'hideUnsyncedPatternsForNetwork'   => 'default', // If patternConfiguration is `hybrid`, site-admins can still show/hide unsynced local and network patterns. If `local_only`, site-admins can only show/hide local patterns. IF `network_only`, site-admins will not see an unsynced patterns option.
-			'disablePatternImporterBlock'      => false, // If false, site admins can still configure this option per site.
-			'disablePatternExporterForNetwork' => false, // If true, site admins will not see a pattern exporter option.
-			'hideCorePatterns'                 => 'default',
-			'hideRemotePatterns'               => 'default',
-			'enableEnhancedView'               => true,
-			'hideAllPatterns'                  => 'default',
-			'hideThemePatterns'                => 'default',
-			'hidePluginPatterns'               => 'default',
-			'hideUncategorizedPatterns'        => 'default',
+			'patternMothershipSiteId'           => 1,
+			'patternConfiguration'              => 'hybrid', // Can be `nework_only`, `local_only`, `hybrid`, or `disabled`.
+			'hideSyncedPatternsForNetwork'      => 'default', // If patternConfiguration is `hybrid`, site-admins can still show/hide synced local and network patterns. If `local_only`, site-admins can only show/hide local patterns. IF `network_only`, site-admins will not see a synced patterns option.
+			'hideUnsyncedPatternsForNetwork'    => 'default', // If patternConfiguration is `hybrid`, site-admins can still show/hide unsynced local and network patterns. If `local_only`, site-admins can only show/hide local patterns. IF `network_only`, site-admins will not see an unsynced patterns option.
+			'disablePatternImporterBlock'       => false, // If false, site admins can still configure this option per site.
+			'disablePatternExporterForNetwork'  => false, // If true, site admins will not see a pattern exporter option.
+			'disablePatternRevisionsForNetwork' => false, // When true and plugin is network-active, disables wp_block revisions on all sites (overrides per-site setting).
+			'hideCorePatterns'                  => 'default',
+			'hideRemotePatterns'                => 'default',
+			'enableEnhancedView'                => true,
+			'hideAllPatterns'                   => 'default',
+			'hideThemePatterns'                 => 'default',
+			'hidePluginPatterns'                => 'default',
+			'hideUncategorizedPatterns'         => 'default',
 		);
 		/**
 		 * Allow options to be extended by plugins.

--- a/php/Patterns.php
+++ b/php/Patterns.php
@@ -94,6 +94,9 @@ class Patterns {
 		// Make patterns exportable.
 		add_filter( 'register_post_type_args', array( $this, 'make_patterns_post_type_exportable' ), 5, 2 );
 
+		// Optionally remove revisions support from wp_block.
+		add_action( 'init', array( $this, 'maybe_remove_pattern_revisions_support' ), 11 );
+
 		// Register tax terms as categories.
 		add_action( 'rest_api_init', array( $this, 'register_terms_as_pattern_categories' ) );
 
@@ -299,6 +302,16 @@ class Patterns {
 			$args['_builtin']   = false;
 		}
 		return $args;
+	}
+
+	/**
+	 * Ensure revisions support is not active if core or another plugin added it after registration.
+	 */
+	public function maybe_remove_pattern_revisions_support() {
+		if ( ! Functions::are_pattern_revisions_disabled() ) {
+			return;
+		}
+		remove_post_type_support( 'wp_block', 'revisions' );
 	}
 
 	/**

--- a/src/js/react/views/main/main.js
+++ b/src/js/react/views/main/main.js
@@ -47,6 +47,7 @@ const Main = () => {
 				enableEnhancedView: data.enableEnhancedView,
 				showMenusUI: data.showMenusUI,
 				makePatternsExportable: data.makePatternsExportable,
+				disablePatternRevisions: data.disablePatternRevisions,
 				patternWranglerMenuLocation: data.patternWranglerMenuLocation,
 				patternsDefaultView:
 					dlxPatternWranglerAdmin.patternsDefaultView || 'all',
@@ -66,6 +67,54 @@ const Main = () => {
 		SendCommand( 'dlx_pw_dismiss_ratings_nag', {
 			nonce: dlxPatternWranglerAdmin.dismissRatingsNagNonce,
 		} ).then( () => {} );
+	};
+
+	/**
+	 * Toggle for disabling wp_block revisions (site option; network may override).
+	 *
+	 * @return {React.ReactNode} Control markup.
+	 */
+	const getDisablePatternRevisionsToggleControl = () => {
+		const networkLocksRevisions =
+			dlxPatternWranglerAdmin.isMultisite &&
+			networkOptions.disablePatternRevisionsForNetwork;
+		return (
+			<div className="dlx-admin__row">
+				<Controller
+					name="disablePatternRevisions"
+					control={ control }
+					render={ ( { field: { onChange, value } } ) => (
+						<ToggleControl
+							label={ __(
+								'Disable Pattern Revisions',
+								'pattern-wrangler'
+							) }
+							checked={ networkLocksRevisions ? true : value }
+							disabled={ networkLocksRevisions }
+							help={ __(
+								'Turn off revisions for the Patterns (wp_block) post type.',
+								'pattern-wrangler'
+							) }
+							onChange={ ( boolValue ) => {
+								onChange( boolValue );
+							} }
+						/>
+					) }
+				/>
+				{ dlxPatternWranglerAdmin.isMultisite && networkLocksRevisions && (
+					<Notice
+						className="dlx-pw-admin-notice"
+						variant="info"
+						icon={ () => <Info /> }
+					>
+						{ __(
+							'This setting is overridden by the network settings.',
+							'pattern-wrangler'
+						) }
+					</Notice>
+				) }
+			</div>
+		);
 	};
 
 	/**
@@ -994,6 +1043,7 @@ const Main = () => {
 											) }
 										/>
 									</div>
+									{ getDisablePatternRevisionsToggleControl() }
 									{ getShowPatternsImporterBlock() }
 									<div className="dlx-admin__row">
 										<Controller

--- a/src/js/react/views/network-settings/settings.js
+++ b/src/js/react/views/network-settings/settings.js
@@ -2,53 +2,28 @@
 import React, { Suspense, useState, useEffect } from 'react';
 import {
 	ToggleControl,
-	TextControl,
-	Tooltip,
-	SelectControl,
-	PanelBody,
-	Popover,
-	BaseControl,
-	Button,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControl as ToggleGroupControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
-import { useAsyncResource } from 'use-async-resource';
-import { AlertTriangle, CheckCircle } from 'lucide-react';
 
-import { __, _n } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useForm, Controller, useWatch, useFormState } from 'react-hook-form';
-import classNames from 'classnames';
-
-// Local imports.
-import SendCommand from '../../utils/SendCommand';
-import Notice from '../../components/Notice';
 import SaveResetButtons from '../../components/SaveResetButtons';
-import SitePicker from '../../components/SitePicker';
 
-const Settings = ( props ) => {
+const Settings = () => {
 	const data = dlxPatternWranglerNetworkAdminSettings.options;
 
-	const [ selectedSiteId, setSelectedSiteId ] = useState(
-		dlxPatternWranglerNetworkAdminSettings.selectedSite
-	);
+	// eslint-disable-next-line no-unused-vars
 	const [ selectedSitePermalink, setSelectedSitePermalink ] = useState(
 		dlxPatternWranglerNetworkAdminSettings.selectedSitePermalink
 	);
+	// eslint-disable-next-line no-unused-vars
 	const [ selectedSiteTitle, setSelectedSiteTitle ] = useState(
 		dlxPatternWranglerNetworkAdminSettings.selectedSiteTitle
 	);
-	const [ selectedSitePatternsUrl, setSelectedSitePatternsUrl ] = useState(
-		dlxPatternWranglerNetworkAdminSettings.selectedSitePatternsUrl
-	);
-	const {
-		control,
-		handleSubmit,
-		getValues,
-		reset,
-		setError,
-		trigger,
-		setValue,
-	} = useForm( {
+	const { control, handleSubmit, reset, setError, trigger } = useForm( {
 		defaultValues: {
 			patternConfiguration: data.patternConfiguration,
 			patternMothershipSiteId: data.patternMothershipSiteId,
@@ -58,6 +33,7 @@ const Settings = ( props ) => {
 			hideUnsyncedPatternsForNetwork: data.hideUnsyncedPatternsForNetwork,
 			disablePatternImporterBlock: data.disablePatternImporterBlock,
 			disablePatternExporterForNetwork: data.disablePatternExporterForNetwork,
+			disablePatternRevisionsForNetwork: data.disablePatternRevisionsForNetwork,
 			hideCorePatterns: data.hideCorePatterns,
 			hideRemotePatterns: data.hideRemotePatterns,
 			hideAllPatterns: data.hideAllPatterns,
@@ -70,56 +46,6 @@ const Settings = ( props ) => {
 	const { errors, isDirty, dirtyFields } = useFormState( {
 		control,
 	} );
-
-	/**
-	 * Get the Site Picker.
-	 *
-	 * @return {React.ReactNode} The Site Picker.
-	 */
-	const getSitePicker = () => {
-		switch ( formValues.patternConfiguration ) {
-			case 'network_only':
-			case 'hybrid':
-				return (
-					<div className="dlx-admin__row">
-						<BaseControl
-							id="dlx-pw-network-settings-default-patterns-source"
-							label={ __( 'Default Patterns Source', 'pattern-wrangler' ) }
-							help={ __(
-								'Select the site that will be used as the source of truth for patterns across the network.',
-								'pattern-wrangler'
-							) }
-						>
-							<SitePicker
-								restEndpoint={
-									dlxPatternWranglerNetworkAdminSettings.restEndpoint
-								}
-								restNonce={ dlxPatternWranglerNetworkAdminSettings.restNonce }
-								selectedSite={ selectedSiteId }
-								savedTitle={ selectedSiteTitle }
-								savedPermalink={ selectedSitePermalink }
-								selectedSitePatternsUrl={ selectedSitePatternsUrl }
-								onItemSelect={ ( e, valueSuggestion ) => {
-									// If value is not null, parse it as an integer.
-									const newValue = valueSuggestion.id
-										? parseInt( valueSuggestion.id )
-										: null;
-									if ( newValue ) {
-										setValue( 'patternMothershipSiteId', newValue );
-										setSelectedSiteId( newValue );
-										setSelectedSitePatternsUrl(
-											valueSuggestion.selectedSitePatternsUrl
-										);
-									}
-								} }
-							/>
-						</BaseControl>
-					</div>
-				);
-			default:
-				return null;
-		}
-	};
 
 	return (
 		<>
@@ -219,7 +145,10 @@ const Settings = ( props ) => {
 															value="default"
 															label={ __( 'Default', 'pattern-wrangler' ) }
 															showTooltip={ true }
-															aria-label={ __( 'No Change. Let site admins decide.', 'pattern-wrangler' ) }
+															aria-label={ __(
+																'No Change. Let site admins decide.',
+																'pattern-wrangler'
+															) }
 														/>
 														<ToggleGroupControlOption
 															value="show"
@@ -331,7 +260,10 @@ const Settings = ( props ) => {
 											render={ ( { field } ) => (
 												<>
 													<ToggleGroupControl
-														label={ __( 'Hide Theme Patterns', 'pattern-wrangler' ) }
+														label={ __(
+															'Hide Theme Patterns',
+															'pattern-wrangler'
+														) }
 														isAdaptiveWidth={ true }
 														value={ field.value }
 														onChange={ ( value ) => {
@@ -374,7 +306,10 @@ const Settings = ( props ) => {
 											render={ ( { field } ) => (
 												<>
 													<ToggleGroupControl
-														label={ __( 'Hide Plugin Patterns', 'pattern-wrangler' ) }
+														label={ __(
+															'Hide Plugin Patterns',
+															'pattern-wrangler'
+														) }
 														isAdaptiveWidth={ true }
 														value={ field.value }
 														onChange={ ( value ) => {
@@ -539,6 +474,26 @@ const Settings = ( props ) => {
 													) }
 													help={ __(
 														'If enabled, the Pattern Exporter will be disabled for all sites in the network.',
+														'pattern-wrangler'
+													) }
+													checked={ field.value }
+													onChange={ field.onChange }
+												/>
+											) }
+										/>
+									</div>
+									<div className="dlx-admin__row">
+										<Controller
+											control={ control }
+											name="disablePatternRevisionsForNetwork"
+											render={ ( { field } ) => (
+												<ToggleControl
+													label={ __(
+														'Disable Pattern Revisions',
+														'pattern-wrangler'
+													) }
+													help={ __(
+														'If enabled, revisions are turned off for the Patterns (wp_block) post type on all sites. This overrides each site’s Pattern Wrangler setting.',
 														'pattern-wrangler'
 													) }
 													checked={ field.value }


### PR DESCRIPTION
Introduces a new setting to allow users to disable revisions for the `wp_block` post type, which is used for patterns. This can help in managing database size and simplifying content history for patterns.

*   Site administrators gain a new toggle in the plugin settings to enable or disable pattern revisions.
*   For multisite installations, network administrators can enforce this setting across all sites, overriding any individual site configurations.
*   Includes the necessary backend logic to conditionally remove revisions support for the `wp_block` post type when the option is active.