### PR TITLE
Introduces Pattern Versions module

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -104,7 +104,10 @@
 		"no-fallthrough": "error",
 		"no-lonely-if": "error",
 		"no-mixed-operators": "error",
-		"no-mixed-spaces-and-tabs": "error",
+		"no-mixed-spaces-and-tabs": [
+			"error",
+			"smart-tabs"
+		],
 		"no-multiple-empty-lines": [
 			"error",
 			{

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+node_modules
+build
+dist
+vendor
+*.min.js
+package-lock.json
+composer.lock
+pattern-wrangler.zip

--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,0 +1,19 @@
+/**
+ * Prettier config aligned with WordPress JS style and this repo’s ESLint
+ * (see .eslintrc.json: tabs, always-multiline commas, semicolons).
+ *
+ * Prettier may still insert a few spaces for alignment inside lines; ESLint uses
+ * no-mixed-spaces-and-tabs "smart-tabs" so that stays valid with tab indentation.
+ */
+module.exports = {
+	useTabs: true,
+	tabWidth: 4,
+	printWidth: 80,
+	singleQuote: true,
+	trailingComma: 'all',
+	semi: true,
+	bracketSpacing: true,
+	bracketSameLine: false,
+	arrowParens: 'always',
+	endOfLine: 'lf',
+};

--- a/pattern-wrangler.php
+++ b/pattern-wrangler.php
@@ -80,6 +80,9 @@ class PatternWrangler {
 		$rest = new Rest();
 		$rest->run();
 
+		$versions = new Versions();
+		$versions->run();
+
 		if ( Functions::is_multisite( true ) ) {
 			$network_admin = new Network_Admin();
 			$network_admin->run();

--- a/pattern-wrangler.php
+++ b/pattern-wrangler.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Pattern Wrangler
  * Plugin URI:        https://dlxplugins.com/plugins/pattern-wrangler/
  * Description:       Manage your block patterns.
- * Version:           2.4.6
+ * Version:           2.5.0-beta1
  * Requires at least: 6.8
  * Requires PHP:      7.2
  * Author:            DLX Plugins
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 require_once __DIR__ . '/functions.php';
 
-define( 'DLXPW_PATTERN_WRANGLER_VERSION', '2.4.6' );
+define( 'DLXPW_PATTERN_WRANGLER_VERSION', '2.5.0-beta1' );
 define( 'DLXPW_PATTERN_WRANGLER_FILE', __FILE__ );
 
 // Support for site-level autoloading.

--- a/php/Functions.php
+++ b/php/Functions.php
@@ -512,6 +512,23 @@ class Functions {
 	}
 
 	/**
+	 * Get the i18n date of a pattern.
+	 *
+	 * @param string $date The date to format.
+	 * @param bool   $with_time Whether to include the time. Default false.
+	 *
+	 * @return string The i18n date.
+	 */
+	public static function get_i18n_date( $date, $with_time = false ) {
+		$date_format = get_option( 'date_format' );
+		$time_format = get_option( 'time_format' );
+		if ( $with_time ) {
+			$date_format .= ' ' . $time_format;
+		}
+		return date_i18n( $date_format, strtotime( $date ) );
+	}
+
+	/**
 	 * Check if a pattern is synced.
 	 *
 	 * @param int $pattern_id The pattern ID.

--- a/php/Options.php
+++ b/php/Options.php
@@ -81,6 +81,7 @@ class Options {
 				case 'makePatternsExportable':
 				case 'enableEnhancedView':
 				case 'disablePatternRevisions':
+				case 'enableVersionsModule':
 					$option = filter_var( $options[ $key ], FILTER_VALIDATE_BOOLEAN );
 					break;
 				default:
@@ -220,6 +221,7 @@ class Options {
 			'loadCustomizerCSSFrontend'    => true,
 			'makePatternsExportable'       => false,
 			'disablePatternRevisions'      => false,
+			'enableVersionsModule'         => false,
 			'enableEnhancedView'           => true,
 			'patternWranglerMenuLocation'  => 'above_media', /* Can be above_media, below_appearance, below_settings, in_appearance. */
 		);

--- a/php/Preview.php
+++ b/php/Preview.php
@@ -22,23 +22,22 @@ class Preview {
 	public function run() {
 		$options              = Options::get_options();
 		$can_preview_frontend = (bool) $options['allowFrontendPatternPreview'];
-		if ( ! $can_preview_frontend ) {
-			return;
+		if ( $can_preview_frontend ) {
+			// Add a preview button to the quick actions for the wp_block post type.
+			add_filter( 'post_row_actions', array( $this, 'add_preview_button_quick_action' ), 10, 2 );
+
+			// Add preview query var to frontend.
+			add_filter( 'query_vars', array( $this, 'add_preview_query_var' ) );
+
+			// Override the template for the wp_block post type.
+			add_filter( 'template_include', array( $this, 'maybe_override_template' ) );
+
+			// Add a preview for the patterns list view.
+			add_action( 'wp_ajax_dlxpw_pattern_preview', array( $this, 'pattern_preview' ) );
 		}
-		// Add a preview button to the quick actions for the wp_block post type.
-		add_filter( 'post_row_actions', array( $this, 'add_preview_button_quick_action' ), 10, 2 );
 
-		// Add preview query var to frontend.
-		add_filter( 'query_vars', array( $this, 'add_preview_query_var' ) );
-
-		// Override the template for the wp_block post type.
-		add_filter( 'template_include', array( $this, 'maybe_override_template' ) );
-
-		// Add a preview button to the top toolbar section.
+		// Block editor toolbar (preview button, pattern code, versions) when preview or versions module is on.
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_preview_toolbar_scripts' ) );
-
-		// Add a preview for the patterns list view.
-		add_action( 'wp_ajax_dlxpw_pattern_preview', array( $this, 'pattern_preview' ) );
 	}
 
 	/**
@@ -80,9 +79,18 @@ class Preview {
 	 */
 	public function enqueue_preview_toolbar_scripts() {
 		$screen = get_current_screen();
-		if ( 'wp_block' !== $screen->post_type ) {
+		if ( ! $screen || 'wp_block' !== $screen->post_type ) {
 			return;
 		}
+
+		$options     = Options::get_options();
+		$versions_on = ! empty( $options['enableVersionsModule'] );
+		$preview_on  = ! empty( $options['allowFrontendPatternPreview'] );
+
+		if ( ! $versions_on && ! $preview_on ) {
+			return;
+		}
+
 		$deps = require_once Functions::get_plugin_dir( 'build/dlx-pw-preview.asset.php' );
 		wp_enqueue_script(
 			'dlx-pattern-wrangler-preview',
@@ -91,25 +99,71 @@ class Preview {
 			$deps['version'],
 			true
 		);
+		wp_enqueue_style(
+			'dlx-pw-patterns-editor',
+			Functions::get_plugin_url( 'dist/dlx-pw-patterns-editor.css' ),
+			array(),
+			$deps['version'],
+			'all'
+		);
 		$post             = get_post();
 		$post_id          = $post ? absint( $post->ID ) : 0;
 		$sync_status_meta = $post_id ? get_post_meta( $post_id, 'wp_pattern_sync_status', true ) : '';
 		$sync_status      = ( 'unsynced' === $sync_status_meta ) ? 'unsynced' : 'synced';
 
+		$pattern_categories         = array();
+		$current_pattern_cat_labels = array();
+		if ( $versions_on ) {
+			$terms = get_terms(
+				array(
+					'taxonomy'   => 'wp_pattern_category',
+					'hide_empty' => false,
+				)
+			);
+			if ( ! is_wp_error( $terms ) ) {
+				foreach ( $terms as $term ) {
+					$pattern_categories[] = array(
+						'id'    => absint( $term->term_id ),
+						'label' => html_entity_decode( $term->name, ENT_QUOTES, 'UTF-8' ),
+						'name'  => sanitize_title( $term->slug ),
+					);
+				}
+			}
+			if ( $post_id ) {
+				$post_terms = wp_get_post_terms( $post_id, 'wp_pattern_category', array( 'fields' => 'all' ) );
+				if ( ! is_wp_error( $post_terms ) ) {
+					foreach ( $post_terms as $term ) {
+						$current_pattern_cat_labels[] = html_entity_decode( $term->name, ENT_QUOTES, 'UTF-8' );
+					}
+				}
+			}
+		}
+
 		wp_localize_script(
 			'dlx-pattern-wrangler-preview',
 			'dlxPatternWranglerPreview',
 			array(
-				'previewUrl'                => Functions::get_pattern_preview_url( get_the_ID() ),
-				'pattern'                   => array(
+				'previewUrl'                   => $preview_on ? Functions::get_pattern_preview_url( get_the_ID() ) : '',
+				'showFrontendPreviewButton'    => $preview_on,
+				'pattern'                      => array(
 					'id'         => $post_id ? absint( $post_id ) : 0,
 					'slug'       => $post ? sanitize_title( $post->post_name ) : '',
 					'syncStatus' => sanitize_text_field( $sync_status ),
 					'siteId'     => absint( get_current_blog_id() ),
+					'title'      => $post ? $post->post_title : '',
 				),
-				'isMultisite'               => is_multisite(),
-				'syncedPatternPopupsActive' => Functions::is_activated( 'synced-pattern-popups/sppopups.php' ),
-				'syncedPatternPopupsUrl'    => esc_url_raw( admin_url( 'themes.php?page=simplest-popup-patterns' ) ),
+				'isMultisite'                  => is_multisite(),
+				'syncedPatternPopupsActive'    => Functions::is_activated( 'synced-pattern-popups/sppopups.php' ),
+				'syncedPatternPopupsUrl'       => esc_url_raw( admin_url( 'themes.php?page=simplest-popup-patterns' ) ),
+				'versions'                     => array(
+					'enabled' => $versions_on,
+				),
+				'restUrl'                      => untrailingslashit( Functions::get_rest_url( 'dlxplugins/pattern-wrangler/v1' ) ),
+				'createNonce'                  => wp_create_nonce( 'dlx-pw-patterns-view-create-pattern' ),
+				'createVersionNonce'           => wp_create_nonce( 'dlx-pw-versions-create-version-' . $post_id ),
+				'getSiteBaseUrl'               => admin_url(),
+				'patternCategories'            => $pattern_categories,
+				'currentPatternCategoryLabels' => $current_pattern_cat_labels,
 			)
 		);
 	}

--- a/php/Rest.php
+++ b/php/Rest.php
@@ -1833,7 +1833,7 @@ class Rest {
 				'id'             => absint( $post->ID ),
 				'title'          => get_the_title( $post ),
 				'description'    => $post->post_excerpt,
-				'date'           => $post->post_date_gmt,
+				'date'           => esc_html( Functions::get_i18n_date( $post->post_date, true ) ),
 				'categoryIds'    => $cat_ids,
 				'content'        => wp_unslash( $post->post_content ),
 				$sync_status_key => $pattern_sync_status_meta,

--- a/php/Rest.php
+++ b/php/Rest.php
@@ -1831,8 +1831,8 @@ class Rest {
 			$pattern_sync_status_meta = ( 'unsynced' === $pattern_sync_status_meta ) ? 'unsynced' : '';
 			$versions[]               = array(
 				'id'             => absint( $post->ID ),
-				'title'          => get_the_title( $post ),
-				'description'    => $post->post_excerpt,
+				'title'          => sanitize_text_field( wp_unslash( get_the_title( $post ) ) ),
+				'description'    => wp_trim_words( sanitize_textarea_field( wp_unslash( $post->post_excerpt ) ), 35 ),
 				'date'           => esc_html( Functions::get_i18n_date( $post->post_date, true ) ),
 				'categoryIds'    => $cat_ids,
 				'content'        => wp_unslash( $post->post_content ),

--- a/php/Rest.php
+++ b/php/Rest.php
@@ -1895,7 +1895,7 @@ class Rest {
 			);
 		}
 
-		$title = sanitize_text_field( $request->get_param( 'title' ) );
+		$title = sanitize_text_field( wp_unslash( $request->get_param( 'title' ) ) );
 		if ( '' === $title ) {
 			return new \WP_Error(
 				'rest_invalid_param',
@@ -1905,6 +1905,8 @@ class Rest {
 		}
 		$excerpt = sanitize_textarea_field( (string) wp_unslash( $request->get_param( 'description' ) ) );
 
+		$current_user = wp_get_current_user();
+
 		$version_id = wp_insert_post(
 			array(
 				'post_title'   => $title,
@@ -1912,7 +1914,8 @@ class Rest {
 				'post_excerpt' => wp_slash( $excerpt ),
 				'post_status'  => 'publish',
 				'post_type'    => Versions::POST_TYPE,
-				'post_parent'  => $parent_id,
+				'post_parent'  => absint( $parent_id ),
+				'post_author'  => absint( $current_user->ID ),
 			),
 			true
 		);

--- a/php/Rest.php
+++ b/php/Rest.php
@@ -1835,6 +1835,7 @@ class Rest {
 				'description'    => $post->post_excerpt,
 				'date'           => $post->post_date_gmt,
 				'categoryIds'    => $cat_ids,
+				'content'        => wp_unslash( $post->post_content ),
 				$sync_status_key => $pattern_sync_status_meta,
 			);
 		}

--- a/php/Rest.php
+++ b/php/Rest.php
@@ -336,6 +336,19 @@ class Rest {
 						return current_user_can( 'edit_posts' );
 					},
 				),
+				array(
+					'methods'             => 'DELETE',
+					'callback'            => array( $this, 'rest_delete_pattern_version' ),
+					'args'                => array(
+						'id' => array(
+							'type'     => 'integer',
+							'required' => true,
+						),
+					),
+					'permission_callback' => function () {
+						return current_user_can( 'delete_posts' );
+					},
+				),
 			)
 		);
 	}
@@ -343,9 +356,9 @@ class Rest {
 	/**
 	 * Delete a pattern.
 	 *
-	 * @param WP_REST_Request $request The REST request.
+	 * @param \WP_REST_Request $request The REST request.
 	 *
-	 * @return WP_REST_Response The REST response.
+	 * @return \WP_REST_Response The REST response.
 	 */
 	public function rest_delete_pattern( $request ) {
 
@@ -380,9 +393,9 @@ class Rest {
 	/**
 	 * Delete a category.
 	 *
-	 * @param WP_REST_Request $request The REST request.
+	 * @param \WP_REST_Request $request The REST request.
 	 *
-	 * @return WP_REST_Response The REST response.
+	 * @return \WP_REST_Response The REST response.
 	 */
 	public function rest_delete_category( $request ) {
 
@@ -427,9 +440,9 @@ class Rest {
 	/**
 	 * Disable a registered category.
 	 *
-	 * @param WP_REST_Request $request The REST request.
+	 * @param \WP_REST_Request $request The REST request.
 	 *
-	 * @return WP_REST_Response The REST response.
+	 * @return \WP_REST_Response The REST response.
 	 */
 	public function rest_disable_category( $request ) {
 
@@ -503,9 +516,9 @@ class Rest {
 	/**
 	 * Re-enable a registered category.
 	 *
-	 * @param WP_REST_Request $request The REST request.
+	 * @param \WP_REST_Request $request The REST request.
 	 *
-	 * @return WP_REST_Response The REST response.
+	 * @return \WP_REST_Response The REST response.
 	 */
 	public function rest_enable_category( $request ) {
 
@@ -1837,6 +1850,8 @@ class Rest {
 				'categoryIds'    => $cat_ids,
 				'content'        => wp_unslash( $post->post_content ),
 				$sync_status_key => $pattern_sync_status_meta,
+				'deleteNonce'    => wp_create_nonce( 'dlx-pw-versions-delete-version-' . $post->ID ),
+				'restoreNonce'   => wp_create_nonce( 'dlx-pw-versions-restore-version-' . $post->ID ),
 			);
 		}
 
@@ -1869,7 +1884,7 @@ class Rest {
 		}
 
 		$nonce = sanitize_text_field( $request->get_param( 'nonce' ) );
-		if ( ! wp_verify_nonce( $nonce, 'dlx-pw-versions-create-version-' . $parent_id ) || ! current_user_can( 'edit_posts' ) ) {
+		if ( ! wp_verify_nonce( $nonce, 'dlx-pw-versions-create-version-' . $parent_id ) ) {
 			return new \WP_Error(
 				'rest_forbidden',
 				__( 'You do not have permission to create versions for this pattern.', 'pattern-wrangler' ),
@@ -1946,6 +1961,58 @@ class Rest {
 			array(
 				'id'    => absint( $version_id ),
 				'title' => $title,
+			)
+		);
+	}
+
+	/**
+	 * Delete a pattern version checkpoint (pw_versions).
+	 *
+	 * @param \WP_REST_Request $request REST request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function rest_delete_pattern_version( $request ) {
+		$options = Options::get_options();
+		if ( empty( $options['enableVersionsModule'] ) ) {
+			return new \WP_Error(
+				'dlx_pw_versions_disabled',
+				__( 'Pattern versions are disabled.', 'pattern-wrangler' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$version_id = absint( $request->get_param( 'id' ) );
+		if ( ! $version_id || ! current_user_can( 'delete_post', $version_id ) ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You cannot delete this version.', 'pattern-wrangler' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$nonce = sanitize_text_field( $request->get_param( 'nonce' ) );
+		if ( ! wp_verify_nonce( $nonce, 'dlx-pw-versions-delete-version-' . $version_id ) ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to delete this version.', 'pattern-wrangler' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$version = get_post( $version_id );
+		if ( ! $version || Versions::POST_TYPE !== $version->post_type ) {
+			return new \WP_Error(
+				'rest_invalid_param',
+				__( 'Invalid version.', 'pattern-wrangler' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		wp_delete_post( $version_id, true );
+
+		return rest_ensure_response(
+			array(
+				'id' => absint( $version_id ),
 			)
 		);
 	}

--- a/php/Rest.php
+++ b/php/Rest.php
@@ -307,6 +307,37 @@ class Rest {
 				},
 			)
 		);
+
+		/**
+		 * Pattern version checkpoints (pw_versions).
+		 */
+		register_rest_route(
+			'dlxplugins/pattern-wrangler/v1',
+			'/versions',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'rest_get_pattern_versions' ),
+					'permission_callback' => function () {
+						return current_user_can( 'edit_posts' );
+					},
+					'args'                => array(
+						'parent' => array(
+							'type'              => 'integer',
+							'required'          => true,
+							'sanitize_callback' => 'absint',
+						),
+					),
+				),
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'rest_create_pattern_version' ),
+					'permission_callback' => function () {
+						return current_user_can( 'edit_posts' );
+					},
+				),
+			)
+		);
 	}
 
 	/**
@@ -804,14 +835,19 @@ class Rest {
 		$pattern_sync_status        = sanitize_text_field( $request->get_param( 'patternSyncStatus' ) );
 		$pattern_copy_id            = sanitize_text_field( $request->get_param( 'patternCopyId' ) ); // 0 if not copying.
 		$disable_registered_pattern = filter_var( $request->get_param( 'disableRegisteredPattern' ), FILTER_VALIDATE_BOOLEAN );
+		$pattern_content_override   = $request->get_param( 'patternContent' );
 
 		// Get categories into right format.
 		$categories = array();
 
-		$maybe_pattern_content = Functions::get_pattern_by_id( $pattern_copy_id );
-		$content               = '';
-		if ( null !== $maybe_pattern_content ) {
-			$content = $maybe_pattern_content;
+		$content = '';
+		if ( is_string( $pattern_content_override ) && '' !== trim( $pattern_content_override ) ) {
+			$content = $pattern_content_override;
+		} else {
+			$maybe_pattern_content = Functions::get_pattern_by_id( $pattern_copy_id );
+			if ( null !== $maybe_pattern_content ) {
+				$content = $maybe_pattern_content;
+			}
 		}
 		$content = Functions::resolve_pattern_markup_for_storage( $content );
 
@@ -1736,5 +1772,177 @@ class Rest {
 			return false;
 		}
 		return true;
+	}
+
+	/**
+	 * List pattern versions for a parent wp_block.
+	 *
+	 * @param \WP_REST_Request $request REST request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function rest_get_pattern_versions( $request ) {
+		$options = Options::get_options();
+		if ( empty( $options['enableVersionsModule'] ) ) {
+			return new \WP_Error(
+				'dlx_pw_versions_disabled',
+				__( 'Pattern versions are disabled.', 'pattern-wrangler' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$parent_id = absint( $request->get_param( 'parent' ) );
+		if ( ! $parent_id || ! current_user_can( 'edit_post', $parent_id ) ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You cannot view versions for this pattern.', 'pattern-wrangler' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$parent = get_post( $parent_id );
+		if ( ! $parent || 'wp_block' !== $parent->post_type ) {
+			return new \WP_Error(
+				'rest_invalid_param',
+				__( 'Invalid pattern.', 'pattern-wrangler' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$posts = get_posts(
+			array(
+				'post_type'      => Versions::POST_TYPE,
+				'post_parent'    => $parent_id,
+				'post_status'    => 'publish',
+				'orderby'        => 'post_date',
+				'order'          => 'DESC',
+				'posts_per_page' => 100,
+			)
+		);
+
+		$sync_status_key = Versions::PATTERN_SYNC_STATUS_META_KEY;
+		$versions        = array();
+		foreach ( $posts as $post ) {
+			$term_ids = wp_get_post_terms( $post->ID, 'wp_pattern_category', array( 'fields' => 'ids' ) );
+			if ( is_wp_error( $term_ids ) || ! is_array( $term_ids ) ) {
+				$term_ids = array();
+			}
+			$cat_ids                  = array_values( array_unique( array_map( 'absint', $term_ids ) ) );
+			$pattern_sync_status_meta = get_post_meta( $post->ID, $sync_status_key, true );
+			$pattern_sync_status_meta = ( 'unsynced' === $pattern_sync_status_meta ) ? 'unsynced' : '';
+			$versions[]               = array(
+				'id'             => absint( $post->ID ),
+				'title'          => get_the_title( $post ),
+				'description'    => $post->post_excerpt,
+				'date'           => $post->post_date_gmt,
+				'categoryIds'    => $cat_ids,
+				$sync_status_key => $pattern_sync_status_meta,
+			);
+		}
+
+		return rest_ensure_response( array( 'versions' => $versions ) );
+	}
+
+	/**
+	 * Create a pattern version checkpoint (pw_versions).
+	 *
+	 * @param \WP_REST_Request $request REST request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function rest_create_pattern_version( $request ) {
+		$options = Options::get_options();
+		if ( empty( $options['enableVersionsModule'] ) ) {
+			return new \WP_Error(
+				'dlx_pw_versions_disabled',
+				__( 'Pattern versions are disabled.', 'pattern-wrangler' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$parent_id = absint( $request->get_param( 'parentId' ) );
+		if ( ! $parent_id || ! current_user_can( 'edit_post', $parent_id ) ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You cannot create versions for this pattern.', 'pattern-wrangler' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$nonce = sanitize_text_field( $request->get_param( 'nonce' ) );
+		if ( ! wp_verify_nonce( $nonce, 'dlx-pw-versions-create-version-' . $parent_id ) || ! current_user_can( 'edit_posts' ) ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to create versions for this pattern.', 'pattern-wrangler' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$parent = get_post( $parent_id );
+		if ( ! $parent || 'wp_block' !== $parent->post_type ) {
+			return new \WP_Error(
+				'rest_invalid_param',
+				__( 'Invalid pattern.', 'pattern-wrangler' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$content = Functions::resolve_pattern_markup_for_storage( $parent->post_content );
+		if ( '' === trim( $content ) ) {
+			return new \WP_Error(
+				'rest_invalid_param',
+				__( 'Version content cannot be empty.', 'pattern-wrangler' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$title = sanitize_text_field( $request->get_param( 'title' ) );
+		if ( '' === $title ) {
+			return new \WP_Error(
+				'rest_invalid_param',
+				__( 'Title is required.', 'pattern-wrangler' ),
+				array( 'status' => 400 )
+			);
+		}
+		$excerpt = sanitize_textarea_field( (string) wp_unslash( $request->get_param( 'description' ) ) );
+
+		$version_id = wp_insert_post(
+			array(
+				'post_title'   => $title,
+				'post_content' => wp_slash( $content ),
+				'post_excerpt' => wp_slash( $excerpt ),
+				'post_status'  => 'publish',
+				'post_type'    => Versions::POST_TYPE,
+				'post_parent'  => $parent_id,
+			),
+			true
+		);
+
+		if ( is_wp_error( $version_id ) ) {
+			return $version_id;
+		}
+
+		$sync_status_key   = Versions::PATTERN_SYNC_STATUS_META_KEY;
+		$parent_terms      = wp_get_post_terms( $parent_id, 'wp_pattern_category', array( 'fields' => 'ids' ) );
+		$category_term_ids = array();
+		if ( ! is_wp_error( $parent_terms ) && is_array( $parent_terms ) ) {
+			$category_term_ids = array_values( array_unique( array_map( 'absint', $parent_terms ) ) );
+		}
+
+		$parent_sync              = get_post_meta( $parent_id, $sync_status_key, true );
+		$pattern_sync_status_meta = ( 'unsynced' === $parent_sync ) ? 'unsynced' : '';
+
+		wp_set_post_terms( $version_id, $category_term_ids, 'wp_pattern_category', false );
+
+		if ( 'unsynced' === $pattern_sync_status_meta ) {
+			update_post_meta( $version_id, $sync_status_key, 'unsynced' );
+		} else {
+			delete_post_meta( $version_id, $sync_status_key );
+		}
+
+		return rest_ensure_response(
+			array(
+				'id'    => absint( $version_id ),
+				'title' => $title,
+			)
+		);
 	}
 }

--- a/php/Rest.php
+++ b/php/Rest.php
@@ -351,6 +351,28 @@ class Rest {
 				),
 			)
 		);
+		/**
+		 * Restore a pattern version checkpoint (pw_versions).
+		 */
+		register_rest_route(
+			'dlxplugins/pattern-wrangler/v1',
+			'/versions/restore',
+			array(
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'rest_restore_pattern_version' ),
+					'permission_callback' => function () {
+						return current_user_can( 'edit_posts' );
+					},
+					'args'                => array(
+						'id' => array(
+							'type'     => 'integer',
+							'required' => true,
+						),
+					),
+				),
+			)
+		);
 	}
 
 	/**
@@ -581,9 +603,9 @@ class Rest {
 	/**
 	 * Re-enable a registered category.
 	 *
-	 * @param WP_REST_Request $request The REST request.
+	 * @param \WP_REST_Request $request The REST request.
 	 *
-	 * @return WP_REST_Response The REST response.
+	 * @return \WP_REST_Response The REST response.
 	 */
 	public function rest_map_category( $request ) {
 
@@ -656,9 +678,9 @@ class Rest {
 	/**
 	 * Pause a pattern.
 	 *
-	 * @param WP_REST_Request $request The REST request.
+	 * @param \WP_REST_Request $request The REST request.
 	 *
-	 * @return WP_REST_Response The REST response.
+	 * @return \WP_REST_Response The REST response.
 	 */
 	public function rest_pause_pattern( $request ) {
 
@@ -705,9 +727,9 @@ class Rest {
 	/**
 	 * Publish a pattern.
 	 *
-	 * @param WP_REST_Request $request The REST request.
+	 * @param \WP_REST_Request $request The REST request.
 	 *
-	 * @return WP_REST_Response The REST response.
+	 * @return \WP_REST_Response The REST response.
 	 */
 	public function rest_publish_pattern( $request ) {
 
@@ -754,9 +776,9 @@ class Rest {
 	/**
 	 * Assign a category to a pattern.
 	 *
-	 * @param WP_REST_Request $request The REST request.
+	 * @param \WP_REST_Request $request The REST request.
 	 *
-	 * @return WP_REST_Response The REST response.
+	 * @return \WP_REST_Response The REST response.
 	 */
 	public function rest_tag_pattern( $request ) {
 
@@ -832,9 +854,9 @@ class Rest {
 	/**
 	 * Create a pattern.
 	 *
-	 * @param WP_REST_Request $request The REST request.
+	 * @param \WP_REST_Request $request The REST request.
 	 *
-	 * @return WP_REST_Response The REST response.
+	 * @return \WP_REST_Response The REST response.
 	 */
 	public function rest_create_pattern( $request ) {
 		// Check nonce and permissions.
@@ -915,9 +937,9 @@ class Rest {
 	/**
 	 * Duplicate a pattern.
 	 *
-	 * @param WP_REST_Request $request The REST request.
+	 * @param \WP_REST_Request $request The REST request.
 	 *
-	 * @return WP_REST_Response The REST response.
+	 * @return \WP_REST_Response The REST response.
 	 */
 	public function rest_duplicate_pattern( $request ) {
 		// Check nonce and permissions.
@@ -988,9 +1010,9 @@ class Rest {
 	/**
 	 * Create a pattern.
 	 *
-	 * @param WP_REST_Request $request The REST request.
+	 * @param \WP_REST_Request $request The REST request.
 	 *
-	 * @return WP_REST_Response The REST response.
+	 * @return \WP_REST_Response The REST response.
 	 */
 	public function rest_update_pattern( $request ) {
 		// Check nonce and permissions.
@@ -1071,9 +1093,9 @@ class Rest {
 	/**
 	 * Create a category.
 	 *
-	 * @param WP_REST_Request $request The REST request.
+	 * @param \WP_REST_Request $request The REST request.
 	 *
-	 * @return WP_REST_Response The REST response.
+	 * @return \WP_REST_Response The REST response.
 	 */
 	public function rest_create_category( $request ) {
 		// Check nonce and permissions.
@@ -1128,9 +1150,9 @@ class Rest {
 	/**
 	 * Edit a registered category.
 	 *
-	 * @param WP_REST_Request $request The REST request.
+	 * @param \WP_REST_Request $request The REST request.
 	 *
-	 * @return WP_REST_Response The REST response.
+	 * @return \WP_REST_Response The REST response.
 	 */
 	public function rest_edit_registered_category( $request ) {
 		// Check nonce and permissions.
@@ -1186,9 +1208,9 @@ class Rest {
 	/**
 	 * Update a category.
 	 *
-	 * @param WP_REST_Request $request The REST request.
+	 * @param \WP_REST_Request $request The REST request.
 	 *
-	 * @return WP_REST_Response The REST response.
+	 * @return \WP_REST_Response The REST response.
 	 */
 	public function rest_update_category( $request ) {
 		// Check nonce and permissions.
@@ -1621,7 +1643,7 @@ class Rest {
 	/**
 	 * Get all categories.
 	 *
-	 * @return WP_REST_Response The REST response.
+	 * @return \WP_REST_Response The REST response.
 	 */
 	public function rest_get_all_categories() {
 		// Check nonce and permissions.
@@ -1644,7 +1666,7 @@ class Rest {
 	/**
 	 * Returns the available sites in the network.
 	 *
-	 * @param WP_REST_Request $request The REST Request data.
+	 * @param \WP_REST_Request $request The REST Request data.
 	 **/
 	public function rest_get_sites( $request ) {
 		$search      = sanitize_text_field( urldecode( $request->get_param( 'search' ) ) );
@@ -1676,9 +1698,9 @@ class Rest {
 	/**
 	 * Get a pattern by ID.
 	 *
-	 * @param WP_REST_Request $request The REST request.
+	 * @param \WP_REST_Request $request The REST request.
 	 *
-	 * @return WP_REST_Response The REST response.
+	 * @return \WP_REST_Response The REST response.
 	 */
 	public function rest_get_pattern( $request ) {
 		// Check nonce and permissions.
@@ -1729,7 +1751,7 @@ class Rest {
 	/**
 	 * Makes sure the search string is valid
 	 *
-	 * @param WP_REST_Request $request The REST request.
+	 * @param \WP_REST_Request $request The REST request.
 	 *
 	 * @return bool Whether to the parameter is numeric or not.
 	 **/
@@ -1745,7 +1767,7 @@ class Rest {
 	/**
 	 * Sanitizes search string
 	 *
-	 * @param WP_REST_Request $request The REST request.
+	 * @param \WP_REST_Request $request The REST request.
 	 *
 	 * @return string Sanitized search string.
 	 **/
@@ -1757,7 +1779,7 @@ class Rest {
 	/**
 	 * Sanitizes the pattern preview image.
 	 *
-	 * @param WP_REST_Request $request The REST request.
+	 * @param \WP_REST_Request $request The REST request.
 	 * @return array Sanitized pattern preview image.
 	 */
 	public function rest_preview_image_sanitize( $request ) {
@@ -1772,7 +1794,7 @@ class Rest {
 	/**
 	 * Validates the pattern preview image.
 	 *
-	 * @param WP_REST_Request $request The REST request.
+	 * @param \WP_REST_Request $request The REST request.
 	 * @return bool Whether the pattern preview image is valid.
 	 */
 	public function rest_preview_image_validate( $request ) {
@@ -2013,6 +2035,147 @@ class Rest {
 		return rest_ensure_response(
 			array(
 				'id' => absint( $version_id ),
+			)
+		);
+	}
+
+	/**
+	 * Restore a pattern version checkpoint (pw_versions).
+	 *
+	 * @param \WP_REST_Request $request REST request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function rest_restore_pattern_version( $request ) {
+		$options = Options::get_options();
+		if ( empty( $options['enableVersionsModule'] ) ) {
+			return new \WP_Error(
+				'dlx_pw_versions_disabled',
+				__( 'Pattern versions are disabled.', 'pattern-wrangler' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$version_id = absint( $request->get_param( 'id' ) );
+		if ( ! $version_id || ! current_user_can( 'edit_post', $version_id ) ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You cannot restore this version.', 'pattern-wrangler' ),
+				array( 'status' => 403 )
+			);
+		}
+		$pattern_id = absint( $request->get_param( 'patternId' ) );
+		if ( ! $pattern_id || ! current_user_can( 'edit_post', $pattern_id ) ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You cannot restore this version.', 'pattern-wrangler' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$nonce = sanitize_text_field( $request->get_param( 'nonce' ) );
+		if ( ! wp_verify_nonce( $nonce, 'dlx-pw-versions-restore-version-' . $version_id ) ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to restore this version.', 'pattern-wrangler' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$version = get_post( $version_id );
+		if ( ! $version || Versions::POST_TYPE !== $version->post_type ) {
+			return new \WP_Error(
+				'rest_invalid_param',
+				__( 'Invalid version.', 'pattern-wrangler' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$can_create_snapshot = boolval( $request->get_param( 'shouldCreateSnapshot' ) );
+		$snapshot_id         = null;
+		if ( $can_create_snapshot ) {
+			$pattern = get_post( $pattern_id );
+			if ( ! $pattern || 'wp_block' !== $pattern->post_type ) {
+				return new \WP_Error(
+					'rest_invalid_param',
+					__( 'Invalid pattern.', 'pattern-wrangler' ),
+					array( 'status' => 400 )
+				);
+			}
+			$content = Functions::resolve_pattern_markup_for_storage( $pattern->post_content );
+			if ( '' === trim( $content ) ) {
+				return new \WP_Error(
+					'rest_invalid_param',
+					__( 'Version content cannot be empty.', 'pattern-wrangler' ),
+					array( 'status' => 400 )
+				);
+			}
+
+			$title   = esc_html__( 'Snapshot Before Restore', 'pattern-wrangler' );
+			$excerpt = esc_html__( 'This is a snapshot of the pattern before it was restored.', 'pattern-wrangler' );
+
+			$current_user = wp_get_current_user();
+
+			$snapshot_id = wp_insert_post(
+				array(
+					'post_title'   => $title,
+					'post_content' => wp_slash( $content ),
+					'post_excerpt' => wp_slash( $excerpt ),
+					'post_status'  => 'publish',
+					'post_type'    => Versions::POST_TYPE,
+					'post_parent'  => absint( $pattern_id ),
+					'post_author'  => absint( $current_user->ID ),
+				),
+				true
+			);
+
+			if ( is_wp_error( $snapshot_id ) ) {
+				return $snapshot_id;
+			}
+
+			$sync_status_key   = Versions::PATTERN_SYNC_STATUS_META_KEY;
+			$parent_terms      = wp_get_post_terms( $pattern_id, 'wp_pattern_category', array( 'fields' => 'ids' ) );
+			$category_term_ids = array();
+			if ( ! is_wp_error( $parent_terms ) && is_array( $parent_terms ) ) {
+				$category_term_ids = array_values( array_unique( array_map( 'absint', $parent_terms ) ) );
+			}
+
+			$parent_sync              = get_post_meta( $pattern_id, $sync_status_key, true );
+			$pattern_sync_status_meta = ( 'unsynced' === $parent_sync ) ? 'unsynced' : '';
+
+			wp_set_post_terms( $snapshot_id, $category_term_ids, 'wp_pattern_category', false );
+
+			if ( 'unsynced' === $pattern_sync_status_meta ) {
+				update_post_meta( $snapshot_id, $sync_status_key, 'unsynced' );
+			} else {
+				delete_post_meta( $snapshot_id, $sync_status_key );
+			}
+		}
+
+		$updated = wp_update_post(
+			array(
+				'ID'           => $pattern_id,
+				'post_content' => wp_slash( $version->post_content ),
+			)
+		);
+
+		// Set the version categories.
+		$version_categories = wp_get_post_terms( $version_id, 'wp_pattern_category', array( 'fields' => 'ids' ) );
+		if ( ! is_wp_error( $version_categories ) && is_array( $version_categories ) ) {
+			wp_set_post_terms( $pattern_id, $version_categories, 'wp_pattern_category', false );
+			$version_categories = array_values( array_unique( array_map( 'absint', $version_categories ) ) );
+		} else {
+			$version_categories = array();
+		}
+
+		if ( is_wp_error( $updated ) ) {
+			return $updated;
+		}
+
+		return rest_ensure_response(
+			array(
+				'content'    => wp_unslash( $version->post_content ),
+				'snapshotId' => absint( $snapshot_id ),
+				'categories' => $version_categories,
 			)
 		);
 	}

--- a/php/Versions.php
+++ b/php/Versions.php
@@ -73,7 +73,7 @@ class Versions {
 			'capability_type'     => 'post',
 			'map_meta_cap'        => true,
 			'hierarchical'        => false,
-			'supports'            => array( 'title', 'editor', 'excerpt' ),
+			'supports'            => array( 'title', 'editor', 'excerpt', 'author' ),
 			'has_archive'         => false,
 			'rewrite'             => false,
 			'query_var'           => false,

--- a/php/Versions.php
+++ b/php/Versions.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Pattern versions (checkpoints) post type registration.
+ *
+ * @package PatternWrangler
+ */
+
+namespace DLXPlugins\PatternWrangler;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'No direct access.' );
+}
+
+/**
+ * Registers and wires the pw_versions post type.
+ */
+class Versions {
+
+	/**
+	 * Post type slug for stored checkpoints.
+	 */
+	public const POST_TYPE = 'pw_versions';
+
+	/**
+	 * Core pattern sync meta key (same as wp_block). Value 'unsynced' means unsynced; meta absent means synced.
+	 */
+	public const PATTERN_SYNC_STATUS_META_KEY = 'wp_pattern_sync_status';
+
+	/**
+	 * Bootstrap hooks.
+	 *
+	 * @return void
+	 */
+	public function run() {
+		add_action( 'init', array( $this, 'register_post_type' ), 6 );
+		add_action( 'init', array( $this, 'register_pattern_category_for_versions' ), 7 );
+	}
+
+	/**
+	 * Use core wp_pattern_category taxonomy on version checkpoints (same as wp_block).
+	 *
+	 * @return void
+	 */
+	public function register_pattern_category_for_versions() {
+		if ( ! taxonomy_exists( 'wp_pattern_category' ) ) {
+			return;
+		}
+		register_taxonomy_for_object_type( 'wp_pattern_category', self::POST_TYPE );
+	}
+
+	/**
+	 * Register the pw_versions post type.
+	 *
+	 * @return void
+	 */
+	public function register_post_type() {
+		$labels = array(
+			'name'          => __( 'Pattern versions', 'pattern-wrangler' ),
+			'singular_name' => __( 'Pattern version', 'pattern-wrangler' ),
+		);
+
+		$args = array(
+			'labels'              => $labels,
+			'description'         => __( 'Checkpoints for block patterns.', 'pattern-wrangler' ),
+			'public'              => false,
+			'publicly_queryable'  => false,
+			'show_ui'             => false,
+			'show_in_menu'        => false,
+			'show_in_admin_bar'   => false,
+			'show_in_nav_menus'   => false,
+			'show_in_rest'        => false,
+			'exclude_from_search' => true,
+			'capability_type'     => 'post',
+			'map_meta_cap'        => true,
+			'hierarchical'        => false,
+			'supports'            => array( 'title', 'editor', 'excerpt' ),
+			'has_archive'         => false,
+			'rewrite'             => false,
+			'query_var'           => false,
+			'can_export'          => false,
+		);
+
+		/**
+		 * Filter registration args for the pattern versions post type.
+		 *
+		 * @param array $args Post type arguments.
+		 */
+		$args = apply_filters( 'dlx_pw_register_pw_versions_args', $args );
+
+		register_post_type( self::POST_TYPE, $args );
+	}
+}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: patterns, block patterns, pattern, pattern builder, synced patterns
 Requires at least: 6.8
 Tested up to: 7.0
 Requires PHP: 7.2
-Stable tag: 2.4.6
+Stable tag: 2.5.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/src/js/blocks/plugins/components/PatternPreviewVersionModal/index.js
+++ b/src/js/blocks/plugins/components/PatternPreviewVersionModal/index.js
@@ -9,8 +9,9 @@ import PatternVersionDropdownMenu from '../PatternVersionDropdownMenu';
 /**
  * Pattern Create Modal.
  *
- * @param {Object} props         The props.
- * @param {Object} props.version The version object from REST (id, title, content, description, date).
+ * @param {Object}   props               The props.
+ * @param {Object}   props.version       The version object from REST (id, title, content, description, date).
+ * @param {Function} props.onActionClick The function to call when a dropdown item is clicked.
  * @return {Object} The rendered component.
  */
 const PatternPreviewVersionModal = ( props ) => {
@@ -26,7 +27,12 @@ const PatternPreviewVersionModal = ( props ) => {
 				onRequestClose={ props.onRequestClose }
 				focusOnMount="firstContentElement"
 				isFullScreen={ true }
-				headerActions={ <PatternVersionDropdownMenu version={ props.version } /> }
+				headerActions={
+					<PatternVersionDropdownMenu
+						version={ props.version }
+						onActionClick={ props.onActionClick }
+					/>
+				}
 			>
 				<div className="dlx-pw-modal-content">
 					<BlockPreview blocks={ blocks } />

--- a/src/js/blocks/plugins/components/PatternPreviewVersionModal/index.js
+++ b/src/js/blocks/plugins/components/PatternPreviewVersionModal/index.js
@@ -1,0 +1,39 @@
+// eslint-disable-next-line no-unused-vars
+import React, { useMemo } from 'react';
+import { Modal } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { parse } from '@wordpress/blocks';
+import { BlockPreview } from '@wordpress/block-editor';
+import PatternVersionDropdownMenu from '../PatternVersionDropdownMenu';
+
+/**
+ * Pattern Create Modal.
+ *
+ * @param {Object} props         The props.
+ * @param {Object} props.version The version object from REST (id, title, content, description, date).
+ * @return {Object} The rendered component.
+ */
+const PatternPreviewVersionModal = ( props ) => {
+	const blocks = useMemo(
+		() => parse( props.version.content ),
+		[ props.version.content ]
+	);
+
+	return (
+		<>
+			<Modal
+				title={ props.version.title ?? __( 'Preview Version', 'pattern-wrangler' ) }
+				onRequestClose={ props.onRequestClose }
+				focusOnMount="firstContentElement"
+				isFullScreen={ true }
+				headerActions={ <PatternVersionDropdownMenu version={ props.version } /> }
+			>
+				<div className="dlx-pw-modal-content">
+					<BlockPreview blocks={ blocks } />
+				</div>
+			</Modal>
+		</>
+	);
+};
+
+export default PatternPreviewVersionModal;

--- a/src/js/blocks/plugins/components/PatternVersionCards/index.js
+++ b/src/js/blocks/plugins/components/PatternVersionCards/index.js
@@ -1,0 +1,97 @@
+/**
+ * WordPress dependencies.
+ */
+import { memo, useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { parse } from '@wordpress/blocks';
+import { BlockPreview } from '@wordpress/block-editor';
+import { Button, DropdownMenu } from '@wordpress/components';
+import { moreVertical } from '@wordpress/icons';
+
+/**
+ * One saved pattern version row with preview.
+ *
+ * @param {Object} props         Props.
+ * @param {Object} props.version Version object from REST (id, title, content, description, date).
+ * @return {JSX.Element} Markup.
+ */
+function PatternVersionCard( { version } ) {
+	const blocks = useMemo( () => parse( version.content ), [ version.content ] );
+
+	return (
+		<div className="dlx-pw-version-item">
+			<div className="dlx-pw-version-item-header">
+				<h4 className="dlx-pw-version-item-header">{ version.title }</h4>
+				<DropdownMenu
+					icon={ moreVertical }
+					label={ __( 'More', 'pattern-wrangler' ) }
+					toggleProps={ {
+						isSmall: true,
+					} }
+					popoverProps={ {
+						placement: 'left-start',
+						offset: 5,
+						className: 'dlx-pw-version-item-popover-content',
+					} }
+					controls={ [
+						{
+							title: __( 'Restore', 'pattern-wrangler' ),
+							onClick: () => console.log( 'restore' ),
+						},
+						{
+							title: __( 'Delete', 'pattern-wrangler' ),
+							onClick: () => console.log( 'delete' ),
+						},
+						{
+							title: __( 'Export', 'pattern-wrangler' ),
+							onClick: () => console.log( 'export' ),
+						},
+						{
+							title: __( 'Copy', 'pattern-wrangler' ),
+							onClick: () => console.log( 'copy' ),
+						},
+					] }
+				/>
+			</div>
+			<div className="dlx-pw-version-item-media">
+				<BlockPreview blocks={ blocks } />
+			</div>
+			<div className="dlx-pw-version-item-content">{ version.description }</div>
+			<div className="dlx-pw-version-item-footer">
+				<Button variant="link" label={ __( 'Restore', 'pattern-wrangler' ) }>
+					{ __( 'Restore', 'pattern-wrangler' ) }
+				</Button>
+				{ ' | ' }
+				<Button
+					variant="link"
+					isDestructive
+					label={ __( 'Delete', 'pattern-wrangler' ) }
+				>
+					{ __( 'Delete', 'pattern-wrangler' ) }
+				</Button>
+			</div>
+			<div className="dlx-pw-version-item-date">{ version.date }</div>
+		</div>
+	);
+}
+
+const MemoPatternVersionCard = memo( PatternVersionCard );
+
+/**
+ * Grid of pattern versions. Memoized so parent state (e.g. modal open) does not re-render previews.
+ *
+ * @param {Object}   props          Props.
+ * @param {Object[]} props.versions Version rows from REST.
+ * @return {JSX.Element} Markup.
+ */
+function PatternVersionCards( { versions } ) {
+	return (
+		<div className="dlx-pw-versions-grid">
+			{ versions.map( ( v ) => (
+				<MemoPatternVersionCard key={ v.id } version={ v } />
+			) ) }
+		</div>
+	);
+}
+
+export default memo( PatternVersionCards );

--- a/src/js/blocks/plugins/components/PatternVersionCards/index.js
+++ b/src/js/blocks/plugins/components/PatternVersionCards/index.js
@@ -5,56 +5,34 @@ import { memo, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { parse } from '@wordpress/blocks';
 import { BlockPreview } from '@wordpress/block-editor';
-import { Button, DropdownMenu } from '@wordpress/components';
-import { moreVertical } from '@wordpress/icons';
+import { Button } from '@wordpress/components';
+import PatternVersionDropdownMenu from '../PatternVersionDropdownMenu';
 
 /**
  * One saved pattern version row with preview.
  *
- * @param {Object} props         Props.
- * @param {Object} props.version Version object from REST (id, title, content, description, date).
+ * @param {Object}   props                Props.
+ * @param {Object}   props.version        Version object from REST (id, title, content, description, date).
+ * @param {Function} props.onPreviewClick The function to call when the preview button is clicked.
  * @return {JSX.Element} Markup.
  */
-function PatternVersionCard( { version } ) {
+function PatternVersionCard( { version, onPreviewClick } ) {
 	const blocks = useMemo( () => parse( version.content ), [ version.content ] );
 
 	return (
 		<div className="dlx-pw-version-item">
 			<div className="dlx-pw-version-item-header">
 				<h4 className="dlx-pw-version-item-header">{ version.title }</h4>
-				<DropdownMenu
-					icon={ moreVertical }
-					label={ __( 'More', 'pattern-wrangler' ) }
-					toggleProps={ {
-						isSmall: true,
-					} }
-					popoverProps={ {
-						placement: 'left-start',
-						offset: 5,
-						className: 'dlx-pw-version-item-popover-content',
-					} }
-					controls={ [
-						{
-							title: __( 'Restore', 'pattern-wrangler' ),
-							onClick: () => console.log( 'restore' ),
-						},
-						{
-							title: __( 'Delete', 'pattern-wrangler' ),
-							onClick: () => console.log( 'delete' ),
-						},
-						{
-							title: __( 'Export', 'pattern-wrangler' ),
-							onClick: () => console.log( 'export' ),
-						},
-						{
-							title: __( 'Copy', 'pattern-wrangler' ),
-							onClick: () => console.log( 'copy' ),
-						},
-					] }
-				/>
+				<PatternVersionDropdownMenu />
 			</div>
 			<div className="dlx-pw-version-item-media">
 				<BlockPreview blocks={ blocks } />
+				<Button
+					variant="link"
+					className="dlx-pw-version-item-preview-button"
+					label={ __( 'Preview', 'pattern-wrangler' ) }
+					onClick={ () => onPreviewClick( version ) }
+				/>
 			</div>
 			<div className="dlx-pw-version-item-content">{ version.description }</div>
 			<div className="dlx-pw-version-item-footer">
@@ -80,15 +58,20 @@ const MemoPatternVersionCard = memo( PatternVersionCard );
 /**
  * Grid of pattern versions. Memoized so parent state (e.g. modal open) does not re-render previews.
  *
- * @param {Object}   props          Props.
- * @param {Object[]} props.versions Version rows from REST.
+ * @param {Object}   props                Props.
+ * @param {Object[]} props.versions       Version rows from REST.
+ * @param {Function} props.onPreviewClick The function to call when the preview button is clicked.
  * @return {JSX.Element} Markup.
  */
-function PatternVersionCards( { versions } ) {
+function PatternVersionCards( { versions, onPreviewClick } ) {
 	return (
 		<div className="dlx-pw-versions-grid">
 			{ versions.map( ( v ) => (
-				<MemoPatternVersionCard key={ v.id } version={ v } />
+				<MemoPatternVersionCard
+					key={ v.id }
+					version={ v }
+					onPreviewClick={ onPreviewClick }
+				/>
 			) ) }
 		</div>
 	);

--- a/src/js/blocks/plugins/components/PatternVersionCards/index.js
+++ b/src/js/blocks/plugins/components/PatternVersionCards/index.js
@@ -14,16 +14,20 @@ import PatternVersionDropdownMenu from '../PatternVersionDropdownMenu';
  * @param {Object}   props                Props.
  * @param {Object}   props.version        Version object from REST (id, title, content, description, date).
  * @param {Function} props.onPreviewClick The function to call when the preview button is clicked.
+ * @param {Function} props.onActionClick  The function to call when a dropdown item is clicked.
  * @return {JSX.Element} Markup.
  */
-function PatternVersionCard( { version, onPreviewClick } ) {
+function PatternVersionCard( { version, onPreviewClick, onActionClick } ) {
 	const blocks = useMemo( () => parse( version.content ), [ version.content ] );
 
 	return (
 		<div className="dlx-pw-version-item">
 			<div className="dlx-pw-version-item-header">
 				<h4 className="dlx-pw-version-item-header">{ version.title }</h4>
-				<PatternVersionDropdownMenu />
+				<PatternVersionDropdownMenu
+					version={ version }
+					onActionClick={ onActionClick }
+				/>
 			</div>
 			<div className="dlx-pw-version-item-media">
 				<BlockPreview blocks={ blocks } />
@@ -36,7 +40,11 @@ function PatternVersionCard( { version, onPreviewClick } ) {
 			</div>
 			<div className="dlx-pw-version-item-content">{ version.description }</div>
 			<div className="dlx-pw-version-item-footer">
-				<Button variant="link" label={ __( 'Restore', 'pattern-wrangler' ) }>
+				<Button
+					variant="link"
+					label={ __( 'Restore', 'pattern-wrangler' ) }
+					onClick={ () => onActionClick( 'restore', version ) }
+				>
 					{ __( 'Restore', 'pattern-wrangler' ) }
 				</Button>
 				{ ' | ' }
@@ -44,6 +52,7 @@ function PatternVersionCard( { version, onPreviewClick } ) {
 					variant="link"
 					isDestructive
 					label={ __( 'Delete', 'pattern-wrangler' ) }
+					onClick={ () => onActionClick( 'delete', version ) }
 				>
 					{ __( 'Delete', 'pattern-wrangler' ) }
 				</Button>
@@ -61,9 +70,10 @@ const MemoPatternVersionCard = memo( PatternVersionCard );
  * @param {Object}   props                Props.
  * @param {Object[]} props.versions       Version rows from REST.
  * @param {Function} props.onPreviewClick The function to call when the preview button is clicked.
+ * @param {Function} props.onActionClick  The function to call when a dropdown item is clicked.
  * @return {JSX.Element} Markup.
  */
-function PatternVersionCards( { versions, onPreviewClick } ) {
+function PatternVersionCards( { versions, onPreviewClick, onActionClick } ) {
 	return (
 		<div className="dlx-pw-versions-grid">
 			{ versions.map( ( v ) => (
@@ -71,6 +81,7 @@ function PatternVersionCards( { versions, onPreviewClick } ) {
 					key={ v.id }
 					version={ v }
 					onPreviewClick={ onPreviewClick }
+					onActionClick={ onActionClick }
 				/>
 			) ) }
 		</div>

--- a/src/js/blocks/plugins/components/PatternVersionCloneToPatternModal/index.js
+++ b/src/js/blocks/plugins/components/PatternVersionCloneToPatternModal/index.js
@@ -1,0 +1,325 @@
+// eslint-disable-next-line no-unused-vars
+import React, { useMemo, useState } from 'react';
+import {
+	TextControl,
+	Modal,
+	Button,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	FormTokenField,
+} from '@wordpress/components';
+import apiFetch from '@wordpress/api-fetch';
+import { AlertTriangle } from 'lucide-react';
+import { escapeHTML } from '@wordpress/escape-html';
+
+import { __, sprintf } from '@wordpress/i18n';
+import { useForm, Controller, useWatch, useFormState } from 'react-hook-form';
+
+// Local imports.
+import Notice from '../../../../react/components/Notice';
+
+/**
+ * Parse non-negative integer (category / version ids).
+ *
+ * @param {*} n Value.
+ * @return {number} Integer.
+ */
+function absInt( n ) {
+	const i = parseInt( n, 10 );
+	return Number.isNaN( i ) ? 0 : i;
+}
+
+/**
+ * Modal to create a new wp_block from a saved pattern version (clone markup).
+ *
+ * @param {Object}   props                Props.
+ * @param {Object}   props.version        Version row from REST (id, title, content, categoryIds, wp_pattern_sync_status).
+ * @param {string}   props.title          Modal title.
+ * @param {Function} props.onRequestClose Close handler.
+ * @return {JSX.Element} Markup.
+ */
+const PatternVersionCloneToPatternModal = ( props ) => {
+	const { version = {}, title, onRequestClose } = props;
+	const preview =
+		typeof dlxPatternWranglerPreview !== 'undefined'
+			? dlxPatternWranglerPreview
+			: {};
+	const originalCategories = preview.patternCategories || [];
+	const categories = originalCategories.map( ( category ) => {
+		return category.label || category.name;
+	} );
+
+	const defaultPatternTitle = useMemo( () => {
+		const baseTitle = ( version.title || '' ).trim();
+		if ( baseTitle ) {
+			return sprintf(
+				// translators: %s: version checkpoint title.
+				__( '%s (copy)', 'pattern-wrangler' ),
+				baseTitle
+			);
+		}
+		return sprintf(
+			// translators: %d: version post ID.
+			__( 'Pattern version %d (copy)', 'pattern-wrangler' ),
+			version.id || 0
+		);
+	}, [ version.title, version.id ] );
+
+	const defaultCategoryLabels = useMemo( () => {
+		const allCats = Array.isArray( preview.patternCategories )
+			? preview.patternCategories
+			: [];
+		const ids = Array.isArray( version.categoryIds ) ? version.categoryIds : [];
+		const labels = [];
+		if ( ids.length && allCats.length ) {
+			for ( const id of ids ) {
+				const found = allCats.find(
+					( c ) => absInt( c.id ) === absInt( id )
+				);
+				if ( found?.label ) {
+					labels.push( escapeHTML( found.label ) );
+				}
+			}
+		}
+		if ( labels.length ) {
+			return labels;
+		}
+		const fallback = preview.currentPatternCategoryLabels || [];
+		return fallback.map( ( label ) => escapeHTML( label ) );
+	}, [
+		version.categoryIds,
+		preview.patternCategories,
+		preview.currentPatternCategoryLabels,
+	] );
+
+	const defaultSyncStatus = useMemo( () => {
+		if ( version.wp_pattern_sync_status === 'unsynced' ) {
+			return 'unsynced';
+		}
+		if ( preview.pattern && preview.pattern.syncStatus === 'unsynced' ) {
+			return 'unsynced';
+		}
+		return 'synced';
+	}, [ version.wp_pattern_sync_status, preview.pattern ] );
+
+	const [ isSaving, setIsSaving ] = useState( false );
+	const [ showExpandedSuggestions, setShowExpandedSuggestions ] = useState( true );
+
+	const { control, handleSubmit, setError } = useForm( {
+		defaultValues: {
+			patternTitle: defaultPatternTitle,
+			patternCategories: defaultCategoryLabels,
+			patternSyncStatus: defaultSyncStatus,
+		},
+	} );
+	// eslint-disable-next-line no-unused-vars
+	const formValues = useWatch( { control } );
+	const { errors } = useFormState( {
+		control,
+	} );
+
+	/**
+	 * Resolve category term id from label.
+	 *
+	 * @param {string} labelValue Category label.
+	 * @return {number} Term id or 0.
+	 */
+	const getIdByValue = ( labelValue ) => {
+		const label = originalCategories.find( ( findLabel ) => {
+			const findNewLabel = findLabel.label || findLabel.name;
+			return findNewLabel.toLowerCase() === labelValue.toLowerCase();
+		} );
+		return label ? label.id : 0;
+	};
+
+	const onSubmit = async( formData ) => {
+		setIsSaving( true );
+		try {
+			const newCategories = ( formData.patternCategories || [] ).map(
+				( category ) => {
+					return {
+						name: category,
+						id: getIdByValue( category ),
+					};
+				}
+			);
+
+			const response = await apiFetch( {
+				path: '/dlxplugins/pattern-wrangler/v1/patterns/create/',
+				method: 'POST',
+				data: {
+					nonce: preview.createNonce,
+					patternTitle: formData.patternTitle,
+					patternCategories: newCategories,
+					patternSyncStatus: formData.patternSyncStatus,
+					patternCopyId: 0,
+					disableRegisteredPattern: false,
+					patternContent: version.content ?? '',
+				},
+			} );
+			if ( response?.error ) {
+				setError( 'patternTitle', { message: response.error } );
+			} else {
+				const patternId = response.patternId;
+				const redirectUrl = encodeURIComponent( window.location.href );
+				window.location.href = `${ preview.getSiteBaseUrl }post.php?post=${ patternId }&action=edit&redirect_to=${ redirectUrl }`;
+			}
+		} catch ( err ) {
+			setError( 'patternTitle', {
+				message:
+					err?.message || __( 'Could not create pattern.', 'pattern-wrangler' ),
+			} );
+		} finally {
+			setIsSaving( false );
+		}
+	};
+
+	const getButtonText = () => {
+		if ( isSaving ) {
+			return __( 'Creating pattern…', 'pattern-wrangler' );
+		}
+		return __( 'Create pattern', 'pattern-wrangler' );
+	};
+
+	return (
+		<>
+			<Modal
+				title={ title || __( 'Clone version to new pattern', 'pattern-wrangler' ) }
+				onRequestClose={ onRequestClose }
+				focusOnMount="firstContentElement"
+			>
+				<div className="dlx-pw-modal-content">
+					<form onSubmit={ handleSubmit( onSubmit ) }>
+						<div className="dlx-pw-modal-admin-row">
+							<Controller
+								control={ control }
+								name="patternTitle"
+								rules={ {
+									required: __(
+										'Pattern title is required.',
+										'pattern-wrangler'
+									),
+								} }
+								render={ ( { field } ) => (
+									<TextControl
+										label={ __( 'Pattern title', 'pattern-wrangler' ) }
+										help={ __(
+											'Enter the title of the new pattern.',
+											'pattern-wrangler'
+										) }
+										value={ field.value }
+										onChange={ ( value ) => field.onChange( value ) }
+										disabled={ isSaving }
+									/>
+								) }
+							/>
+						</div>
+						<div className="dlx-pw-modal-admin-row">
+							<Controller
+								control={ control }
+								name="patternCategories"
+								render={ ( { field } ) => (
+									<>
+										<FormTokenField
+											label={ __( 'Categories', 'pattern-wrangler' ) }
+											help={ __(
+												'Enter the categories of the pattern.',
+												'pattern-wrangler'
+											) }
+											value={ field.value }
+											onChange={ ( tokens ) => {
+												field.onChange( tokens );
+												setShowExpandedSuggestions( false );
+											} }
+											tokenizeOnBlur={ true }
+											tokenizeOnSpace={ false }
+											allowMultiple={ true }
+											placeholder={ __( 'Add a category', 'pattern-wrangler' ) }
+											suggestions={ categories }
+											disabled={ isSaving }
+											__experimentalShowHowTo={ false }
+											maxSuggestions={ 20 }
+											onInputChange={ ( input ) => {
+												if ( input.length > 1 ) {
+													setShowExpandedSuggestions( false );
+												} else {
+													setShowExpandedSuggestions( true );
+												}
+											} }
+											__experimentalExpandOnFocus={
+												( field.value.length === 0 && showExpandedSuggestions ) ||
+												showExpandedSuggestions
+											}
+										/>
+										<p className="description">
+											{ __(
+												'Separate with commas or press the Enter key.',
+												'pattern-wrangler'
+											) }
+										</p>
+									</>
+								) }
+							/>
+						</div>
+						<div className="dlx-pw-modal-admin-row">
+							<Controller
+								control={ control }
+								name="patternSyncStatus"
+								render={ ( { field } ) => (
+									<ToggleGroupControl
+										label={ __( 'Sync status', 'pattern-wrangler' ) }
+										isAdaptiveWidth={ true }
+										value={ field.value }
+										onChange={ ( value ) => {
+											field.onChange( value );
+										} }
+										disabled={ isSaving }
+									>
+										<ToggleGroupControlOption
+											value="synced"
+											label={ __( 'Synced', 'pattern-wrangler' ) }
+											showTooltip={ true }
+											aria-label={ __( 'Synced', 'pattern-wrangler' ) }
+										/>
+										<ToggleGroupControlOption
+											value="unsynced"
+											label={ __( 'Unsynced', 'pattern-wrangler' ) }
+											showTooltip={ true }
+											aria-label={ __( 'Unsynced', 'pattern-wrangler' ) }
+										/>
+									</ToggleGroupControl>
+								) }
+							/>
+						</div>
+						<div className="dlx-pw-modal-admin-row dlx-pw-modal-admin-row-buttons">
+							<Button variant="primary" type="submit" disabled={ isSaving }>
+								{ getButtonText() }
+							</Button>
+							<Button
+								variant="secondary"
+								onClick={ onRequestClose }
+								disabled={ isSaving }
+							>
+								{ __( 'Cancel', 'pattern-wrangler' ) }
+							</Button>
+						</div>
+						{ errors?.patternTitle && (
+							<Notice
+								className="dlx-pw-admin-notice"
+								status="error"
+								inline={ true }
+								icon={ () => <AlertTriangle /> }
+							>
+								{ errors.patternTitle.message }
+							</Notice>
+						) }
+					</form>
+				</div>
+			</Modal>
+		</>
+	);
+};
+
+export default PatternVersionCloneToPatternModal;

--- a/src/js/blocks/plugins/components/PatternVersionCloneToPatternModal/index.js
+++ b/src/js/blocks/plugins/components/PatternVersionCloneToPatternModal/index.js
@@ -13,7 +13,7 @@ import {
 import apiFetch from '@wordpress/api-fetch';
 import { AlertTriangle } from 'lucide-react';
 import { escapeHTML } from '@wordpress/escape-html';
-
+import classnames from 'classnames';
 import { __, sprintf } from '@wordpress/i18n';
 import { useForm, Controller, useWatch, useFormState } from 'react-hook-form';
 
@@ -75,9 +75,7 @@ const PatternVersionCloneToPatternModal = ( props ) => {
 		const labels = [];
 		if ( ids.length && allCats.length ) {
 			for ( const id of ids ) {
-				const found = allCats.find(
-					( c ) => absInt( c.id ) === absInt( id )
-				);
+				const found = allCats.find( ( c ) => absInt( c.id ) === absInt( id ) );
 				if ( found?.label ) {
 					labels.push( escapeHTML( found.label ) );
 				}
@@ -186,7 +184,7 @@ const PatternVersionCloneToPatternModal = ( props ) => {
 	return (
 		<>
 			<Modal
-				title={ title || __( 'Clone version to new pattern', 'pattern-wrangler' ) }
+				title={ title || __( 'Clone Version to New Pattern', 'pattern-wrangler' ) }
 				onRequestClose={ onRequestClose }
 				focusOnMount="firstContentElement"
 			>
@@ -209,6 +207,11 @@ const PatternVersionCloneToPatternModal = ( props ) => {
 											'Enter the title of the new pattern.',
 											'pattern-wrangler'
 										) }
+										className={ classnames( {
+											'is-required': true,
+											'is-error': errors?.patternTitle,
+											'has-error': errors?.patternTitle,
+										} ) }
 										value={ field.value }
 										onChange={ ( value ) => field.onChange( value ) }
 										disabled={ isSaving }

--- a/src/js/blocks/plugins/components/PatternVersionCreateModal/index.js
+++ b/src/js/blocks/plugins/components/PatternVersionCreateModal/index.js
@@ -53,7 +53,7 @@ const PatternVersionCreateModal = ( props ) => {
 	const onSubmit = async( formData ) => {
 		setIsSaving( true );
 
-		const response = await apiFetch( {
+		apiFetch( {
 			path: '/dlxplugins/pattern-wrangler/v1/versions',
 			method: 'POST',
 			data: {
@@ -62,13 +62,20 @@ const PatternVersionCreateModal = ( props ) => {
 				description: formData.versionDescription,
 				nonce: props.patternNonce,
 			},
-		} );
-		if ( response?.error ) {
-			setError( 'versionTitle', { message: response.error } );
-		} else {
-			props.onCreate( response );
-		}
-		setIsSaving( false );
+		} )
+			.then( ( response ) => {
+				if ( response?.error ) {
+					setError( 'versionTitle', { message: response.error } );
+				} else {
+					props.onCreate( response );
+				}
+			} )
+			.catch( ( error ) => {
+				setError( 'versionTitle', { message: error.message } );
+			} )
+			.finally( () => {
+				setIsSaving( false );
+			} );
 	};
 
 	/**

--- a/src/js/blocks/plugins/components/PatternVersionCreateModal/index.js
+++ b/src/js/blocks/plugins/components/PatternVersionCreateModal/index.js
@@ -13,7 +13,7 @@ import { __ } from '@wordpress/i18n';
 import { useForm, Controller, useWatch, useFormState } from 'react-hook-form';
 
 // Local imports.
-import Notice from '../../../../components/Notice';
+import Notice from '../../../../react/components/Notice';
 
 /**
  * Pattern Create Modal.

--- a/src/js/blocks/plugins/components/PatternVersionCreateModal/index.js
+++ b/src/js/blocks/plugins/components/PatternVersionCreateModal/index.js
@@ -8,6 +8,7 @@ import {
 } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { AlertTriangle } from 'lucide-react';
+import classnames from 'classnames';
 
 import { __ } from '@wordpress/i18n';
 import { useForm, Controller, useWatch, useFormState } from 'react-hook-form';
@@ -112,6 +113,11 @@ const PatternVersionCreateModal = ( props ) => {
 											'Enter the title of the version.',
 											'pattern-wrangler'
 										) }
+										className={ classnames( {
+											'is-required': true,
+											'is-error': errors?.versionTitle,
+											'has-error': errors?.versionTitle,
+										} ) }
 										value={ field.value }
 										onChange={ ( value ) => field.onChange( value ) }
 										disabled={ isSaving }
@@ -123,15 +129,12 @@ const PatternVersionCreateModal = ( props ) => {
 							<Controller
 								control={ control }
 								name="versionDescription"
-								rules={ {
-									required: __(
-										'Version description is required.',
-										'pattern-wrangler'
-									),
-								} }
 								render={ ( { field } ) => (
 									<TextareaControl
-										label={ __( 'Version Description', 'pattern-wrangler' ) }
+										label={ __(
+											'Version Description (optional)',
+											'pattern-wrangler'
+										) }
 										help={ __(
 											'Enter the description of the version.',
 											'pattern-wrangler'

--- a/src/js/blocks/plugins/components/PatternVersionDropdownMenu/index.js
+++ b/src/js/blocks/plugins/components/PatternVersionDropdownMenu/index.js
@@ -32,15 +32,19 @@ export default function PatternVersionDropdownMenu( {
 					onClick: () => onActionClick( 'restore', version ),
 				},
 				{
+					title: __( 'Clone to Pattern', 'pattern-wrangler' ),
+					onClick: () => onActionClick( 'clone', version ),
+				},
+				{
 					title: __( 'Delete', 'pattern-wrangler' ),
 					onClick: () => onActionClick( 'delete', version ),
 				},
 				{
-					title: __( 'Export', 'pattern-wrangler' ),
+					title: __( 'Export to JSON', 'pattern-wrangler' ),
 					onClick: () => onActionClick( 'export', version ),
 				},
 				{
-					title: __( 'Copy', 'pattern-wrangler' ),
+					title: __( 'Copy to Clipboard', 'pattern-wrangler' ),
 					onClick: () => onActionClick( 'copy', version ),
 				},
 			] }

--- a/src/js/blocks/plugins/components/PatternVersionDropdownMenu/index.js
+++ b/src/js/blocks/plugins/components/PatternVersionDropdownMenu/index.js
@@ -5,11 +5,15 @@ import { __ } from '@wordpress/i18n';
 /**
  * A dropdown menu for a pattern version.
  *
- * @param {Object} props         The props.
- * @param {Object} props.version The version object from REST (id, title, content, description, date).
+ * @param {Object}   props               The props.
+ * @param {Object}   props.version       Version object from REST (id, title, content, description, date).
+ * @param {Function} props.onActionClick The function to call when a dropdown item is clicked.
  * @return {JSX.Element} The dropdown menu.
  */
-export default function PatternVersionDropdownMenu( { version } ) {
+export default function PatternVersionDropdownMenu( {
+	version = {},
+	onActionClick = () => {},
+} ) {
 	return (
 		<DropdownMenu
 			icon={ moreVertical }
@@ -25,19 +29,19 @@ export default function PatternVersionDropdownMenu( { version } ) {
 			controls={ [
 				{
 					title: __( 'Restore', 'pattern-wrangler' ),
-					onClick: () => console.log( 'restore' ),
+					onClick: () => onActionClick( 'restore', version ),
 				},
 				{
 					title: __( 'Delete', 'pattern-wrangler' ),
-					onClick: () => console.log( 'delete' ),
+					onClick: () => onActionClick( 'delete', version ),
 				},
 				{
 					title: __( 'Export', 'pattern-wrangler' ),
-					onClick: () => console.log( 'export' ),
+					onClick: () => onActionClick( 'export', version ),
 				},
 				{
 					title: __( 'Copy', 'pattern-wrangler' ),
-					onClick: () => console.log( 'copy' ),
+					onClick: () => onActionClick( 'copy', version ),
 				},
 			] }
 		/>

--- a/src/js/blocks/plugins/components/PatternVersionDropdownMenu/index.js
+++ b/src/js/blocks/plugins/components/PatternVersionDropdownMenu/index.js
@@ -1,0 +1,45 @@
+import { DropdownMenu } from '@wordpress/components';
+import { moreVertical } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * A dropdown menu for a pattern version.
+ *
+ * @param {Object} props         The props.
+ * @param {Object} props.version The version object from REST (id, title, content, description, date).
+ * @return {JSX.Element} The dropdown menu.
+ */
+export default function PatternVersionDropdownMenu( { version } ) {
+	return (
+		<DropdownMenu
+			icon={ moreVertical }
+			label={ __( 'More', 'pattern-wrangler' ) }
+			toggleProps={ {
+				isSmall: true,
+			} }
+			popoverProps={ {
+				placement: 'left-start',
+				offset: 5,
+				className: 'dlx-pw-version-item-popover-content',
+			} }
+			controls={ [
+				{
+					title: __( 'Restore', 'pattern-wrangler' ),
+					onClick: () => console.log( 'restore' ),
+				},
+				{
+					title: __( 'Delete', 'pattern-wrangler' ),
+					onClick: () => console.log( 'delete' ),
+				},
+				{
+					title: __( 'Export', 'pattern-wrangler' ),
+					onClick: () => console.log( 'export' ),
+				},
+				{
+					title: __( 'Copy', 'pattern-wrangler' ),
+					onClick: () => console.log( 'copy' ),
+				},
+			] }
+		/>
+	);
+}

--- a/src/js/blocks/plugins/components/VersionDeleteModal/index.js
+++ b/src/js/blocks/plugins/components/VersionDeleteModal/index.js
@@ -1,0 +1,136 @@
+// eslint-disable-next-line no-unused-vars
+import React, { Suspense, useState, useEffect } from 'react';
+import { Modal, Button } from '@wordpress/components';
+import apiFetch from '@wordpress/api-fetch';
+import { AlertTriangle } from 'lucide-react';
+import { __ } from '@wordpress/i18n';
+import { useForm, useWatch, useFormState } from 'react-hook-form';
+
+// Local imports.
+import Notice from '../../../../react/components/Notice';
+
+/**
+ * Version Delete Modal.
+ *
+ * @param {Object}   props                      The props.
+ * @param {string}   props.id                   The id of the version.
+ * @param {string}   props.nonce                The nonce of the version.
+ * @param {boolean}  props.shouldCreateSnapshot Whether to show the modal again.
+ * @param {Function} props.onRequestClose       The function to call when the modal is closed.
+ * @param {Function} props.onDelete             The function to call when the version is deleted.
+ * @return {Object} The rendered component.
+ */
+const VersionDeleteModal = ( props ) => {
+	const [ isSaving, setIsSaving ] = useState( false );
+	const { control, handleSubmit, setError } = useForm( {
+		defaultValues: {
+			shouldCreateSnapshot: true,
+		},
+	} );
+	const formValues = useWatch( { control } );
+	const { errors } = useFormState( {
+		control,
+	} );
+
+	const onSubmit = async() => {
+		setIsSaving( true );
+
+		const path = '/dlxplugins/pattern-wrangler/v1/versions';
+
+		const response = await apiFetch( {
+			path,
+			method: 'DELETE',
+			data: {
+				id: props.id,
+				nonce: props.nonce,
+			},
+		} );
+		if ( response.error ) {
+			setError( 'versionTitle', response.error );
+		}
+		props.onDelete( response );
+		setIsSaving( false );
+	};
+
+	useEffect( () => {
+		if ( props.doNotShowAgain ) {
+			onSubmit( formValues );
+		}
+	}, [] );
+	if ( props.doNotShowAgain ) {
+		return null;
+	}
+	/**
+	 * Get the button text.
+	 *
+	 * @return {string} The button text.
+	 */
+	const getButtonText = () => {
+		let buttonText = __( 'Delete Version', 'pattern-wrangler' );
+		if ( isSaving ) {
+			buttonText = __( 'Deleting Version…', 'pattern-wrangler' );
+		}
+		return buttonText;
+	};
+
+	/**
+	 * Get the modal title.
+	 *
+	 * @return {string} The modal title.
+	 */
+	const getModalTitle = () => {
+		return __( 'Delete Version', 'pattern-wrangler' );
+	};
+
+	return (
+		<>
+			<Modal
+				title={ getModalTitle() }
+				onRequestClose={ props.onRequestClose }
+				focusOnMount="firstContentElement"
+			>
+				<div className="dlx-pw-modal-content">
+					<form onSubmit={ handleSubmit( onSubmit ) }>
+						<div className="dlx-pw-modal-admin-row">
+							<p className="description">
+								{ __(
+									'Are you sure you want to delete this version? This action cannot be undone.',
+									'pattern-wrangler'
+								) }
+							</p>
+						</div>
+						<div className="dlx-pw-modal-admin-row dlx-pw-modal-admin-row-buttons">
+							<Button
+								variant="primary"
+								type="submit"
+								isDestructive={ true }
+								disabled={ isSaving }
+							>
+								{ getButtonText() }
+							</Button>
+							<Button
+								variant="secondary"
+								onClick={ props.onRequestClose }
+								disabled={ isSaving }
+							>
+								{ __( 'Cancel', 'pattern-wrangler' ) }
+							</Button>
+						</div>
+						{ errors?.versionTitle && (
+							<Notice
+								className="dlx-pw-admin-notice"
+								status="error"
+								inline={ true }
+								icon={ () => <AlertTriangle /> }
+							>
+								{ errors.versionTitle.message }
+							</Notice>
+						) }
+					</form>
+				</div>
+			</Modal>
+		</>
+	);
+};
+
+export default VersionDeleteModal;

--- a/src/js/blocks/plugins/components/VersionDeleteModal/index.js
+++ b/src/js/blocks/plugins/components/VersionDeleteModal/index.js
@@ -34,19 +34,27 @@ const VersionDeleteModal = ( props ) => {
 
 		const path = '/dlxplugins/pattern-wrangler/v1/versions';
 
-		const response = await apiFetch( {
+		apiFetch( {
 			path,
 			method: 'DELETE',
 			data: {
 				id: props.id,
 				nonce: props.nonce,
 			},
-		} );
-		if ( response.error ) {
-			setError( 'versionTitle', response.error );
-		}
-		props.onDelete( response );
-		setIsSaving( false );
+		} )
+			.then( ( response ) => {
+				if ( response.error ) {
+					setError( 'versionTitle', response.error );
+				} else {
+					props.onDelete( response );
+				}
+			} )
+			.catch( ( error ) => {
+				setError( 'versionTitle', error.message );
+			} )
+			.finally( () => {
+				setIsSaving( false );
+			} );
 	};
 
 	useEffect( () => {

--- a/src/js/blocks/plugins/components/VersionRestoreModal/index.js
+++ b/src/js/blocks/plugins/components/VersionRestoreModal/index.js
@@ -39,7 +39,7 @@ const VersionRestoreModal = ( props ) => {
 
 		const path = '/dlxplugins/pattern-wrangler/v1/versions/restore';
 
-		const response = await apiFetch( {
+		apiFetch( {
 			path,
 			method: 'POST',
 			data: {
@@ -48,12 +48,20 @@ const VersionRestoreModal = ( props ) => {
 				nonce: props.nonce,
 				shouldCreateSnapshot: formValues.shouldCreateSnapshot,
 			},
-		} );
-		if ( response.error ) {
-			setError( 'versionTitle', response.error );
-		}
-		props.onRestore( response, formValues.shouldCreateSnapshot );
-		setIsSaving( false );
+		} )
+			.then( ( response ) => {
+				if ( response.error ) {
+					setError( 'versionTitle', response.error );
+				} else {
+					props.onRestore( response, formValues.shouldCreateSnapshot );
+				}
+			} )
+			.catch( ( error ) => {
+				setError( 'versionTitle', error.message );
+			} )
+			.finally( () => {
+				setIsSaving( false );
+			} );
 	};
 
 	/**

--- a/src/js/blocks/plugins/components/VersionRestoreModal/index.js
+++ b/src/js/blocks/plugins/components/VersionRestoreModal/index.js
@@ -1,10 +1,10 @@
 // eslint-disable-next-line no-unused-vars
 import React, { Suspense, useState, useEffect } from 'react';
-import { Modal, Button } from '@wordpress/components';
+import { Modal, Button, ToggleControl } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { AlertTriangle } from 'lucide-react';
 import { __ } from '@wordpress/i18n';
-import { useForm, useWatch, useFormState } from 'react-hook-form';
+import { useForm, useWatch, useFormState, Controller } from 'react-hook-form';
 
 // Local imports.
 import Notice from '../../../../react/components/Notice';
@@ -12,17 +12,22 @@ import Notice from '../../../../react/components/Notice';
 /**
  * Version Delete Modal.
  *
- * @param {Object}   props                The props.
- * @param {string}   props.id             The id of the version.
- * @param {string}   props.nonce          The nonce of the version.
- * @param {Function} props.onRequestClose The function to call when the modal is closed.
- * @param {Function} props.onDelete       The function to call when the version is deleted.
+ * @param {Object}   props                      The props.
+ * @param {string}   props.id                   The id of the version.
+ * @param {string}   props.nonce                The nonce of the version.
+ * @param {boolean}  props.shouldCreateSnapshot Whether to show the modal again.
+ * @param {boolean}  props.isEditedPostDirty    Whether the edited post is dirty. Used to determine if a snapshot can be created.
+ * @param {Function} props.onRequestClose       The function to call when the modal is closed.
+ * @param {Function} props.onRestore            The function to call when the version is restored.
  * @return {Object} The rendered component.
  */
-const VersionDeleteModal = ( props ) => {
+const VersionRestoreModal = ( props ) => {
 	const [ isSaving, setIsSaving ] = useState( false );
+	const [ canCreateSnapshot ] = useState( ! props.isEditedPostDirty );
 	const { control, handleSubmit, setError } = useForm( {
-		defaultValues: {},
+		defaultValues: {
+			shouldCreateSnapshot: canCreateSnapshot,
+		},
 	} );
 	const formValues = useWatch( { control } );
 	const { errors } = useFormState( {
@@ -32,40 +37,34 @@ const VersionDeleteModal = ( props ) => {
 	const onSubmit = async() => {
 		setIsSaving( true );
 
-		const path = '/dlxplugins/pattern-wrangler/v1/versions';
+		const path = '/dlxplugins/pattern-wrangler/v1/versions/restore';
 
 		const response = await apiFetch( {
 			path,
-			method: 'DELETE',
+			method: 'POST',
 			data: {
 				id: props.id,
+				patternId: props.patternId,
 				nonce: props.nonce,
+				shouldCreateSnapshot: formValues.shouldCreateSnapshot,
 			},
 		} );
 		if ( response.error ) {
 			setError( 'versionTitle', response.error );
 		}
-		props.onDelete( response );
+		props.onRestore( response );
 		setIsSaving( false );
 	};
 
-	useEffect( () => {
-		if ( props.doNotShowAgain ) {
-			onSubmit( formValues );
-		}
-	}, [] );
-	if ( props.doNotShowAgain ) {
-		return null;
-	}
 	/**
 	 * Get the button text.
 	 *
 	 * @return {string} The button text.
 	 */
 	const getButtonText = () => {
-		let buttonText = __( 'Delete Version', 'pattern-wrangler' );
+		let buttonText = __( 'Restore Version', 'pattern-wrangler' );
 		if ( isSaving ) {
-			buttonText = __( 'Deleting Version…', 'pattern-wrangler' );
+			buttonText = __( 'Restoring Version…', 'pattern-wrangler' );
 		}
 		return buttonText;
 	};
@@ -76,7 +75,42 @@ const VersionDeleteModal = ( props ) => {
 	 * @return {string} The modal title.
 	 */
 	const getModalTitle = () => {
-		return __( 'Delete Version', 'pattern-wrangler' );
+		return __( 'Restore Version', 'pattern-wrangler' );
+	};
+
+	const getSnapshotToggle = () => {
+		return (
+			<div className="dlx-pw-modal-admin-row">
+				{ props.isEditedPostDirty && (
+					<Notice
+						className="dlx-pw-admin-notice"
+						status="warning"
+						inline={ true }
+						icon={ () => <AlertTriangle /> }
+					>
+						{ __(
+							'The existing pattern must be saved before creating a snapshot.',
+							'pattern-wrangler'
+						) }
+					</Notice>
+				) }
+				<Controller
+					control={ control }
+					name="shouldCreateSnapshot"
+					render={ ( { field } ) => (
+						<ToggleControl
+							label={ __(
+								'Create Snapshot of the current pattern',
+								'pattern-wrangler'
+							) }
+							checked={ field.value }
+							onChange={ ( value ) => field.onChange( value ) }
+							disabled={ isSaving || ! canCreateSnapshot }
+						/>
+					) }
+				/>
+			</div>
+		);
 	};
 
 	return (
@@ -91,11 +125,12 @@ const VersionDeleteModal = ( props ) => {
 						<div className="dlx-pw-modal-admin-row">
 							<p className="description">
 								{ __(
-									'Are you sure you want to delete this version? This action cannot be undone.',
+									'Are you sure you want to restore this version?',
 									'pattern-wrangler'
 								) }
 							</p>
 						</div>
+						{ getSnapshotToggle() }
 						<div className="dlx-pw-modal-admin-row dlx-pw-modal-admin-row-buttons">
 							<Button
 								variant="primary"
@@ -130,4 +165,4 @@ const VersionDeleteModal = ( props ) => {
 	);
 };
 
-export default VersionDeleteModal;
+export default VersionRestoreModal;

--- a/src/js/blocks/plugins/components/VersionRestoreModal/index.js
+++ b/src/js/blocks/plugins/components/VersionRestoreModal/index.js
@@ -52,7 +52,7 @@ const VersionRestoreModal = ( props ) => {
 		if ( response.error ) {
 			setError( 'versionTitle', response.error );
 		}
-		props.onRestore( response );
+		props.onRestore( response, formValues.shouldCreateSnapshot );
 		setIsSaving( false );
 	};
 

--- a/src/js/blocks/plugins/pattern-preview.js
+++ b/src/js/blocks/plugins/pattern-preview.js
@@ -6,6 +6,7 @@ import { PluginPostStatusInfo } from '@wordpress/editor';
 import { getQueryArg } from '@wordpress/url';
 import { subscribe } from '@wordpress/data';
 import './pattern-code.js';
+import './pattern-versions.js';
 
 /**
  * Render a Preview Button.
@@ -13,6 +14,9 @@ import './pattern-code.js';
  * @return {Object} The rendered component.
  */
 const PatternPreviewButton = () => {
+	if ( ! dlxPatternWranglerPreview?.showFrontendPreviewButton ) {
+		return null;
+	}
 	return (
 		<PluginPostStatusInfo
 			icon="external"
@@ -20,9 +24,7 @@ const PatternPreviewButton = () => {
 			className="dlx-pw-preview-sidebar"
 		>
 			<div className="dlx-pw-preview-sidebar-content">
-				<Tooltip
-					text={ __( 'Preview Pattern in new tab', 'pattern-wrangler' ) }
-				>
+				<Tooltip text={ __( 'Preview Pattern in new tab', 'pattern-wrangler' ) }>
 					<Button
 						variant="tertiary"
 						href={ dlxPatternWranglerPreview.previewUrl }
@@ -59,7 +61,10 @@ registerPlugin( 'dlx-pattern-wrangler-preview-button', {
 
 // This takes in a redirect_to query arg and stores it in localStorage. It then subscribes to the block editor data, and when the back button is finally rendered, it will redirect to the stored redirect_to URL.
 const RedirectToPatternsPage = () => {
-	const redirectTo = useMemo( () => getQueryArg( window.location.href, 'redirect_to' ), [] );
+	const redirectTo = useMemo(
+		() => getQueryArg( window.location.href, 'redirect_to' ),
+		[]
+	);
 	useEffect( () => {
 		if ( redirectTo ) {
 			localStorage.setItem( 'dlx-pw-redirect-to', redirectTo );
@@ -79,11 +84,15 @@ registerPlugin( 'dlx-pattern-wrangler-redirect-to-patterns-page', {
  */
 const subscribeToData = () => {
 	const unsubscribe = subscribe( () => {
-		const backButton = document.querySelector( '.edit-post-fullscreen-mode-close' );
+		const backButton = document.querySelector(
+			'.edit-post-fullscreen-mode-close'
+		);
 		if ( backButton ) {
 			const redirecTo = localStorage.getItem( 'dlx-pw-redirect-to' );
 			if ( redirecTo ) {
-				backButton.href = decodeURIComponent( localStorage.getItem( 'dlx-pw-redirect-to' ) );
+				backButton.href = decodeURIComponent(
+					localStorage.getItem( 'dlx-pw-redirect-to' )
+				);
 				localStorage.removeItem( 'dlx-pw-redirect-to' );
 			}
 			unsubscribe();

--- a/src/js/blocks/plugins/pattern-versions.js
+++ b/src/js/blocks/plugins/pattern-versions.js
@@ -2,19 +2,16 @@ import { useState, useEffect, useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 import { PluginSidebar } from '@wordpress/editor';
-import { parse } from '@wordpress/blocks';
-import { BlockPreview } from '@wordpress/block-editor';
-import { moreVertical } from '@wordpress/icons';
 import {
 	Button,
 	Spinner,
 	PanelBody,
 	BaseControl,
-	DropdownMenu,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
-import PatternVersionCreateModal from '../../react/views/patterns/components/PatternVersionCreateModal';
+import PatternVersionCreateModal from './components/PatternVersionCreateModal';
+import PatternVersionCards from './components/PatternVersionCards';
 
 const PatternWranglerIcon = (
 	<svg
@@ -132,72 +129,7 @@ const PatternVersionsSidebar = () => {
 					<div className="dlx-pw-admin-row">
 						{ loadingList && <Spinner /> }
 						{ ! loadingList && versions.length > 0 && (
-							<div className="dlx-pw-versions-grid">
-								{ versions.map( ( v ) => (
-									<>
-										<div key={ v.id } className="dlx-pw-version-item">
-											<div className="dlx-pw-version-item-header">
-												<h4 className="dlx-pw-version-item-header">
-													{ v.title }
-												</h4>
-												<DropdownMenu
-													icon={ moreVertical }
-													label={ __( 'More', 'pattern-wrangler' ) }
-													toggleProps={ {
-														isSmall: true,
-													} }
-													popoverProps={ {
-														placement: 'left-start',
-														offset: 5,
-														className: 'dlx-pw-version-item-popover-content',
-													} }
-													controls={ [
-														{
-															title: __( 'Restore', 'pattern-wrangler' ),
-															onClick: () => console.log( 'restore' ),
-														},
-														{
-															title: __( 'Delete', 'pattern-wrangler' ),
-															onClick: () => console.log( 'delete' ),
-														},
-														{
-															title: __( 'Export', 'pattern-wrangler' ),
-															onClick: () => console.log( 'export' ),
-														},
-														{
-															title: __( 'Copy', 'pattern-wrangler' ),
-															onClick: () => console.log( 'copy' ),
-														},
-													] }
-												/>
-											</div>
-											<div className="dlx-pw-version-item-media">
-												<BlockPreview blocks={ parse( v.content ) } />
-											</div>
-											<div className="dlx-pw-version-item-content">
-												{ v.description }
-											</div>
-											<div className="dlx-pw-version-item-footer">
-												<Button
-													variant="link"
-													label={ __( 'Restore', 'pattern-wrangler' ) }
-												>
-													{ __( 'Restore', 'pattern-wrangler' ) }
-												</Button>
-												{ ' | ' }
-												<Button
-													variant="link"
-													isDestructive
-													label={ __( 'Delete', 'pattern-wrangler' ) }
-												>
-													{ __( 'Delete', 'pattern-wrangler' ) }
-												</Button>
-											</div>
-											<div className="dlx-pw-version-item-date">{ v.date }</div>
-										</div>
-									</>
-								) ) }
-							</div>
+							<PatternVersionCards versions={ versions } />
 						) }
 						{ ! loadingList && postId && versions.length === 0 && (
 							<p className="description">

--- a/src/js/blocks/plugins/pattern-versions.js
+++ b/src/js/blocks/plugins/pattern-versions.js
@@ -3,7 +3,8 @@ import { __, sprintf } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 import { PluginSidebar } from '@wordpress/editor';
 import { Button, Spinner, PanelBody, BaseControl } from '@wordpress/components';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, dispatch } from '@wordpress/data';
+import { parse } from '@wordpress/blocks';
 import apiFetch from '@wordpress/api-fetch';
 import { downloadBlob } from '@wordpress/blob';
 import { copyToClipboard } from '../../utils/pattern-code-helpers';
@@ -11,6 +12,7 @@ import PatternVersionCreateModal from './components/PatternVersionCreateModal';
 import PatternVersionCards from './components/PatternVersionCards';
 import PatternPreviewVersionModal from './components/PatternPreviewVersionModal';
 import VersionDeleteModal from './components/VersionDeleteModal/index';
+import VersionRestoreModal from './components/VersionRestoreModal/index';
 
 const PatternWranglerIcon = (
 	<svg
@@ -90,6 +92,7 @@ const PatternVersionsSidebar = () => {
 	const [ createVersionModalOpen, setCreateVersionModalOpen ] = useState( false );
 	const [ previewVersionModalOpen, setPreviewVersionModalOpen ] = useState( null );
 	const [ isDeleteModalOpen, setIsDeleteModalOpen ] = useState( false );
+	const [ isRestoreModalOpen, setIsRestoreModalOpen ] = useState( false );
 
 	const fetchVersions = useCallback( async() => {
 		if ( ! postId ) {
@@ -181,10 +184,12 @@ const PatternVersionsSidebar = () => {
 					break;
 				}
 				case 'restore':
+					closeAllModals();
+					setIsRestoreModalOpen( { version } );
 					break;
 			}
 		},
-		[ closeAllModals, createNotice ]
+		[ closeAllModals, createNotice, setIsRestoreModalOpen ]
 	);
 
 	return (
@@ -287,6 +292,22 @@ const PatternVersionsSidebar = () => {
 							)
 						);
 					} }
+				/>
+			) }
+			{ isRestoreModalOpen && (
+				<VersionRestoreModal
+					id={ isRestoreModalOpen.version.id }
+					nonce={ isRestoreModalOpen.version.restoreNonce }
+					patternId={ postId }
+					onRequestClose={ () => setIsRestoreModalOpen( false ) }
+					onRestore={ ( { content, categories } ) => {
+						const blocks = parse( content );
+						dispatch( 'core/editor' ).resetEditorBlocks( blocks );
+						dispatch( 'core/editor' ).editPost( { categories } );
+						dispatch( 'core/editor' ).savePost();
+						setIsRestoreModalOpen( false );
+					} }
+					isEditedPostDirty={ hasUnsavedChanges }
 				/>
 			) }
 		</>

--- a/src/js/blocks/plugins/pattern-versions.js
+++ b/src/js/blocks/plugins/pattern-versions.js
@@ -8,6 +8,7 @@ import apiFetch from '@wordpress/api-fetch';
 import PatternVersionCreateModal from './components/PatternVersionCreateModal';
 import PatternVersionCards from './components/PatternVersionCards';
 import PatternPreviewVersionModal from './components/PatternPreviewVersionModal';
+import VersionDeleteModal from './components/VersionDeleteModal/index';
 
 const PatternWranglerIcon = (
 	<svg
@@ -64,6 +65,7 @@ const PatternVersionsSidebar = () => {
 	const [ loadingList, setLoadingList ] = useState( false );
 	const [ createVersionModalOpen, setCreateVersionModalOpen ] = useState( false );
 	const [ previewVersionModalOpen, setPreviewVersionModalOpen ] = useState( null );
+	const [ isDeleteModalOpen, setIsDeleteModalOpen ] = useState( false );
 
 	const fetchVersions = useCallback( async() => {
 		if ( ! postId ) {
@@ -88,9 +90,29 @@ const PatternVersionsSidebar = () => {
 		}
 	}, [ postId, createNotice ] );
 
+	const closeAllModals = useCallback( () => {
+		setCreateVersionModalOpen( false );
+		setPreviewVersionModalOpen( null );
+	}, [] );
+
 	useEffect( () => {
 		fetchVersions();
 	}, [ fetchVersions ] );
+
+	const handleActionClick = useCallback( ( action, version ) => {
+		switch ( action ) {
+			case 'delete':
+				closeAllModals();
+				setIsDeleteModalOpen( { version } );
+				break;
+			case 'export':
+				break;
+			case 'copy':
+				break;
+			case 'restore':
+				break;
+		}
+	}, [] );
 
 	return (
 		<>
@@ -131,9 +153,7 @@ const PatternVersionsSidebar = () => {
 								onPreviewClick={ ( version ) => {
 									setPreviewVersionModalOpen( { version } );
 								} }
-								onActionClick={ ( action, version ) => {
-									console.log( 'action', action, version );
-								} }
+								onActionClick={ handleActionClick }
 							/>
 						) }
 						{ ! loadingList && postId && versions.length === 0 && (
@@ -169,8 +189,30 @@ const PatternVersionsSidebar = () => {
 				<PatternPreviewVersionModal
 					version={ previewVersionModalOpen.version }
 					onRequestClose={ () => setPreviewVersionModalOpen( false ) }
-					onActionClick={ ( action, version ) => {
-						console.log( 'action', action, version );
+					onActionClick={ handleActionClick }
+				/>
+			) }
+			{ isDeleteModalOpen && (
+				<VersionDeleteModal
+					id={ isDeleteModalOpen.version.id }
+					nonce={ isDeleteModalOpen.version.deleteNonce }
+					onRequestClose={ () => setIsDeleteModalOpen( false ) }
+					onDelete={ () => {
+						setIsDeleteModalOpen( false );
+						createNotice(
+							'success',
+							sprintf(
+								// translators: %s: the version title.
+								__( 'Pattern Version %s deleted.', 'pattern-wrangler' ),
+								isDeleteModalOpen.version.title
+							),
+							{ type: 'snackbar', isDismissible: true }
+						);
+						setVersions(
+							versions.filter(
+								( version ) => version.id !== isDeleteModalOpen.version.id
+							)
+						);
 					} }
 				/>
 			) }

--- a/src/js/blocks/plugins/pattern-versions.js
+++ b/src/js/blocks/plugins/pattern-versions.js
@@ -2,7 +2,23 @@ import { useState, useEffect, useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 import { PluginSidebar } from '@wordpress/editor';
-import { Button, Spinner, PanelBody } from '@wordpress/components';
+import { parse } from '@wordpress/blocks';
+import { BlockPreview } from '@wordpress/block-editor';
+import {
+	Button,
+	Spinner,
+	PanelBody,
+	Card,
+	CardMedia,
+	CardBody,
+	CardHeader,
+	CardFooter,
+	CardDivider,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalText as Text,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalHeading as Heading,
+} from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 import PatternVersionCreateModal from '../../react/views/patterns/components/PatternVersionCreateModal';
@@ -109,41 +125,65 @@ const PatternVersionsSidebar = () => {
 							{ __( 'Save Version', 'pattern-wrangler' ) }
 						</Button>
 					</div>
-
-					{ loadingList && <Spinner /> }
-					{ ! loadingList && versions.length > 0 && (
-						<ul
-							className="dlx-pw-versions-list"
-							style={ {
-								listStyle: 'disc',
-								marginLeft: '1.25em',
-								maxHeight: '200px',
-								overflow: 'auto',
-							} }
-						>
-							{ versions.map( ( v ) => (
-								<li key={ v.id } style={ { marginBottom: '6px' } }>
-									<strong>{ v.title }</strong>
-									{ v.description ? (
-										<span
-											className="description"
-											style={ {
-												display: 'block',
-												fontSize: '12px',
-											} }
-										>
-											{ v.description }
-										</span>
-									) : null }
-								</li>
-							) ) }
-						</ul>
-					) }
-					{ ! loadingList && postId && versions.length === 0 && (
-						<p className="description">
-							{ __( 'No versions yet.', 'pattern-wrangler' ) }
-						</p>
-					) }
+					<div className="dlx-pw-admin-row">
+						{ loadingList && <Spinner /> }
+						{ ! loadingList && versions.length > 0 && (
+							<div className="dlx-pw-versions-grid">
+								{ versions.map( ( v ) => (
+									<>
+										<div key={ v.id } className="dlx-pw-version-item">
+											<div className="dlx-pw-version-item-header">
+												<h4 className="dlx-pw-version-item-header">
+													{ v.title }
+												</h4>
+											</div>
+											<div className="dlx-pw-version-item-media">
+												<BlockPreview blocks={ parse( v.content ) } />
+											</div>
+											<div className="dlx-pw-version-item-content">
+												{ v.description }
+											</div>
+											<div className="dlx-pw-version-item-footer">
+												<Button
+													variant="link"
+													label={ __( 'Restore', 'pattern-wrangler' ) }
+												>
+													{ __( 'Restore', 'pattern-wrangler' ) }
+												</Button>
+												{ ' | ' }
+												<Button
+													variant="link"
+													isDestructive
+													label={ __( 'Delete', 'pattern-wrangler' ) }
+												>
+													{ __( 'Delete', 'pattern-wrangler' ) }
+												</Button>
+												{ ' | ' }
+												<Button
+													variant="link"
+													label={ __( 'Export', 'pattern-wrangler' ) }
+												>
+													{ __( 'Export', 'pattern-wrangler' ) }
+												</Button>
+												{ ' | ' }
+												<Button
+													variant="link"
+													label={ __( 'Copy', 'pattern-wrangler' ) }
+												>
+													{ __( 'Copy', 'pattern-wrangler' ) }
+												</Button>
+											</div>
+										</div>
+									</>
+								) ) }
+							</div>
+						) }
+						{ ! loadingList && postId && versions.length === 0 && (
+							<p className="description">
+								{ __( 'No versions yet.', 'pattern-wrangler' ) }
+							</p>
+						) }
+					</div>
 				</PanelBody>
 			</PluginSidebar>
 			{ createVersionModalOpen && (

--- a/src/js/blocks/plugins/pattern-versions.js
+++ b/src/js/blocks/plugins/pattern-versions.js
@@ -4,7 +4,14 @@ import { registerPlugin } from '@wordpress/plugins';
 import { PluginSidebar } from '@wordpress/editor';
 import { parse } from '@wordpress/blocks';
 import { BlockPreview } from '@wordpress/block-editor';
-import { Button, Spinner, PanelBody, BaseControl } from '@wordpress/components';
+import { moreVertical } from '@wordpress/icons';
+import {
+	Button,
+	Spinner,
+	PanelBody,
+	BaseControl,
+	DropdownMenu,
+} from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 import PatternVersionCreateModal from '../../react/views/patterns/components/PatternVersionCreateModal';
@@ -133,6 +140,36 @@ const PatternVersionsSidebar = () => {
 												<h4 className="dlx-pw-version-item-header">
 													{ v.title }
 												</h4>
+												<DropdownMenu
+													icon={ moreVertical }
+													label={ __( 'More', 'pattern-wrangler' ) }
+													toggleProps={ {
+														isSmall: true,
+													} }
+													popoverProps={ {
+														placement: 'left-start',
+														offset: 5,
+														className: 'dlx-pw-version-item-popover-content',
+													} }
+													controls={ [
+														{
+															title: __( 'Restore', 'pattern-wrangler' ),
+															onClick: () => console.log( 'restore' ),
+														},
+														{
+															title: __( 'Delete', 'pattern-wrangler' ),
+															onClick: () => console.log( 'delete' ),
+														},
+														{
+															title: __( 'Export', 'pattern-wrangler' ),
+															onClick: () => console.log( 'export' ),
+														},
+														{
+															title: __( 'Copy', 'pattern-wrangler' ),
+															onClick: () => console.log( 'copy' ),
+														},
+													] }
+												/>
 											</div>
 											<div className="dlx-pw-version-item-media">
 												<BlockPreview blocks={ parse( v.content ) } />

--- a/src/js/blocks/plugins/pattern-versions.js
+++ b/src/js/blocks/plugins/pattern-versions.js
@@ -1,0 +1,183 @@
+import { useState, useEffect, useCallback } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { registerPlugin } from '@wordpress/plugins';
+import { PluginSidebar } from '@wordpress/editor';
+import { Button, Spinner, PanelBody } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import apiFetch from '@wordpress/api-fetch';
+import PatternVersionCreateModal from '../../react/views/patterns/components/PatternVersionCreateModal';
+
+const PatternWranglerIcon = (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		xmlSpace="preserve"
+		viewBox="0 0 538 556"
+		fillRule="evenodd"
+		clipRule="evenodd"
+		strokeLinejoin="round"
+		strokeMiterlimit={ 2 }
+		width="24px"
+		height="24px"
+	>
+		<path
+			d="m537.48 116.82-66.686 42.182-83.734 52.984v.017l-118.594 75.036-34.676-19.5-167.502-94.106L.017 136.188 269.129 0z"
+			fill="currentColor"
+			fillRule="nonzero"
+		/>
+		<path
+			d="m537.48 206.254-66.653 42.182-.1.05-83.684 52.951-118.593 75.036-118.428-66.554-83.717-47.053c-.033-.016-.05-.033-.083-.049L.017 225.622l60.754-30.75 78.764 44.253 83.751 47.053 40.243 22.615a10.8 10.8 0 0 0 5.252 1.375c1.988 0 3.976-.547 5.716-1.657l123.994-78.449 78.946-49.952z"
+			fill="currentColor"
+			fillRule="nonzero"
+		/>
+		<path
+			d="m537.48 295.704-66.653 42.165c-.033.034-.083.05-.116.083L268.45 465.923 66.288 352.333a.4.4 0 0 0-.083-.05L0 315.089l60.755-30.751 78.763 44.253 123.995 69.668a10.7 10.7 0 0 0 5.235 1.376c1.988 0 3.976-.547 5.716-1.657l123.994-78.449 78.946-49.953z"
+			fill="currentColor"
+			fillRule="nonzero"
+		/>
+		<path
+			d="M537.48 385.138 268.45 555.356.017 404.522l60.754-30.75L263.529 487.71a10.7 10.7 0 0 0 5.236 1.375c1.988 0 3.976-.547 5.716-1.657l202.94-128.418z"
+			fill="currentColor"
+			fillRule="nonzero"
+		/>
+	</svg>
+);
+
+/**
+ * Pattern versions sidebar for wp_block.
+ *
+ * @return {JSX.Element} Markup.
+ */
+const PatternVersionsSidebar = () => {
+	const { postId } = useSelect( ( selectStore ) => {
+		const editor = selectStore( 'core/editor' );
+		return {
+			postId: editor.getCurrentPostId(),
+		};
+	}, [] );
+
+	const { createNotice } = useDispatch( 'core/notices' );
+
+	const [ versions, setVersions ] = useState( [] );
+	const [ loadingList, setLoadingList ] = useState( false );
+	const [ createVersionModalOpen, setCreateVersionModalOpen ] = useState( false );
+
+	const fetchVersions = useCallback( async() => {
+		if ( ! postId ) {
+			setVersions( [] );
+			return;
+		}
+		setLoadingList( true );
+		try {
+			const res = await apiFetch( {
+				path: `/dlxplugins/pattern-wrangler/v1/versions?parent=${ postId }`,
+			} );
+			setVersions( res.versions || [] );
+		} catch ( err ) {
+			const message =
+				err?.message || __( 'Could not load versions.', 'pattern-wrangler' );
+			createNotice( 'error', message, {
+				type: 'snackbar',
+				isDismissible: true,
+			} );
+		} finally {
+			setLoadingList( false );
+		}
+	}, [ postId, createNotice ] );
+
+	useEffect( () => {
+		fetchVersions();
+	}, [ fetchVersions ] );
+
+	return (
+		<>
+			<PluginSidebar
+				name="dlx-pattern-wrangler-versions"
+				title={ __( 'Pattern versions', 'pattern-wrangler' ) }
+				className="dlx-pw-preview-sidebar"
+				icon={ PatternWranglerIcon }
+			>
+				<PanelBody
+					title={ __( 'Pattern versions', 'pattern-wrangler' ) }
+					icon={ PatternWranglerIcon }
+				>
+					<div className="dlx-pw-admin-row">
+						<Button
+							variant="secondary"
+							onClick={ () => setCreateVersionModalOpen( true ) }
+							disabled={ ! postId }
+						>
+							{ __( 'Save Version', 'pattern-wrangler' ) }
+						</Button>
+					</div>
+
+					{ loadingList && <Spinner /> }
+					{ ! loadingList && versions.length > 0 && (
+						<ul
+							className="dlx-pw-versions-list"
+							style={ {
+								listStyle: 'disc',
+								marginLeft: '1.25em',
+								maxHeight: '200px',
+								overflow: 'auto',
+							} }
+						>
+							{ versions.map( ( v ) => (
+								<li key={ v.id } style={ { marginBottom: '6px' } }>
+									<strong>{ v.title }</strong>
+									{ v.description ? (
+										<span
+											className="description"
+											style={ {
+												display: 'block',
+												fontSize: '12px',
+											} }
+										>
+											{ v.description }
+										</span>
+									) : null }
+								</li>
+							) ) }
+						</ul>
+					) }
+					{ ! loadingList && postId && versions.length === 0 && (
+						<p className="description">
+							{ __( 'No versions yet.', 'pattern-wrangler' ) }
+						</p>
+					) }
+				</PanelBody>
+			</PluginSidebar>
+			{ createVersionModalOpen && (
+				<PatternVersionCreateModal
+					title={ __( 'Create new version', 'pattern-wrangler' ) }
+					patternId={ postId }
+					patternNonce={ dlxPatternWranglerPreview.createVersionNonce }
+					onRequestClose={ () => setCreateVersionModalOpen( false ) }
+					onCreate={ ( response ) => {
+						setCreateVersionModalOpen( false );
+						createNotice(
+							'success',
+							sprintf(
+								// translators: %s: the version title.
+								__( 'Pattern Version %s created.', 'pattern-wrangler' ),
+								response.title
+							),
+							{ type: 'snackbar', isDismissible: true }
+						);
+						fetchVersions();
+					} }
+				/>
+			) }
+		</>
+	);
+};
+
+const PatternVersionsPlugin = () => {
+	if ( ! dlxPatternWranglerPreview?.versions?.enabled ) {
+		return null;
+	}
+	return <PatternVersionsSidebar />;
+};
+
+registerPlugin( 'dlx-pattern-wrangler-versions', {
+	render: PatternVersionsPlugin,
+} );

--- a/src/js/blocks/plugins/pattern-versions.js
+++ b/src/js/blocks/plugins/pattern-versions.js
@@ -77,13 +77,17 @@ const getVersionExportFileBase = ( title, versionId ) => {
  * @return {JSX.Element} Markup.
  */
 const PatternVersionsSidebar = () => {
-	const { postId, hasUnsavedChanges } = useSelect( ( selectStore ) => {
-		const editor = selectStore( 'core/editor' );
-		return {
-			postId: editor.getCurrentPostId(),
-			hasUnsavedChanges: editor.isEditedPostDirty(),
-		};
-	}, [] );
+	const { postId, hasUnsavedChanges, blockContent } = useSelect(
+		( selectStore ) => {
+			const editor = selectStore( 'core/editor' );
+			return {
+				postId: editor.getCurrentPostId(),
+				hasUnsavedChanges: editor.isEditedPostDirty(),
+				blockContent: editor.getEditedPostContent(),
+			};
+		},
+		[]
+	);
 
 	const { createNotice } = useDispatch( 'core/notices' );
 
@@ -192,6 +196,26 @@ const PatternVersionsSidebar = () => {
 		[ closeAllModals, createNotice, setIsRestoreModalOpen ]
 	);
 
+	/**
+	 * Get the help text for the save version button.
+	 *
+	 * @return {string} The help text.
+	 */
+	const getSaveVersionHelp = () => {
+		if ( hasUnsavedChanges ) {
+			return __(
+				'Save or update the pattern in the editor before creating a version.',
+				'pattern-wrangler'
+			);
+		}
+		if ( ! blockContent ) {
+			return __(
+				'The pattern has no content. Please add some content to the pattern before creating a version.',
+				'pattern-wrangler'
+			);
+		}
+		return undefined;
+	};
 	return (
 		<>
 			<PluginSidebar
@@ -205,19 +229,12 @@ const PatternVersionsSidebar = () => {
 						<BaseControl
 							id="dlx-pw-versions-save-version"
 							label={ __( 'Save Version', 'pattern-wrangler' ) }
-							help={
-								hasUnsavedChanges
-									? __(
-										'Save or update the pattern in the editor before creating a version.',
-										'pattern-wrangler'
-									  )
-									: undefined
-							}
+							help={ getSaveVersionHelp() }
 						>
 							<Button
 								variant="secondary"
 								onClick={ () => setCreateVersionModalOpen( true ) }
-								disabled={ ! postId || hasUnsavedChanges }
+								disabled={ ! postId || hasUnsavedChanges || ! blockContent }
 							>
 								{ __( 'Save New Version', 'pattern-wrangler' ) }
 							</Button>

--- a/src/js/blocks/plugins/pattern-versions.js
+++ b/src/js/blocks/plugins/pattern-versions.js
@@ -300,11 +300,14 @@ const PatternVersionsSidebar = () => {
 					nonce={ isRestoreModalOpen.version.restoreNonce }
 					patternId={ postId }
 					onRequestClose={ () => setIsRestoreModalOpen( false ) }
-					onRestore={ ( { content, categories } ) => {
+					onRestore={ ( { content, categories }, shouldCreateSnapshot ) => {
 						const blocks = parse( content );
 						dispatch( 'core/editor' ).resetEditorBlocks( blocks );
 						dispatch( 'core/editor' ).editPost( { categories } );
 						dispatch( 'core/editor' ).savePost();
+						if ( shouldCreateSnapshot ) {
+							fetchVersions();
+						}
 						setIsRestoreModalOpen( false );
 					} }
 					isEditedPostDirty={ hasUnsavedChanges }

--- a/src/js/blocks/plugins/pattern-versions.js
+++ b/src/js/blocks/plugins/pattern-versions.js
@@ -5,6 +5,7 @@ import { PluginSidebar } from '@wordpress/editor';
 import { Button, Spinner, PanelBody, BaseControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
+import { downloadBlob } from '@wordpress/blob';
 import { copyToClipboard } from '../../utils/pattern-code-helpers';
 import PatternVersionCreateModal from './components/PatternVersionCreateModal';
 import PatternVersionCards from './components/PatternVersionCards';
@@ -45,6 +46,28 @@ const PatternWranglerIcon = (
 		/>
 	</svg>
 );
+
+/**
+ * Build a safe download filename base for a version JSON export.
+ *
+ * @param {string} title     Version title.
+ * @param {number} versionId Version post ID when title is empty.
+ * @return {string} File base without extension.
+ */
+const getVersionExportFileBase = ( title, versionId ) => {
+	let base = ( title || '' ).trim();
+	if ( ! base ) {
+		base = sprintf( 'pattern-version-%d', versionId );
+	}
+	base = base
+		.replace( /[/\\?%*:|"<>]+/g, '-' )
+		.replace( /\s+/g, '-' )
+		.replace( /^-+|-+$/g, '' );
+	if ( ! base ) {
+		base = sprintf( 'pattern-version-%d', versionId );
+	}
+	return base;
+};
 
 /**
  * Pattern versions sidebar for wp_block.
@@ -100,35 +123,69 @@ const PatternVersionsSidebar = () => {
 		fetchVersions();
 	}, [ fetchVersions ] );
 
-	const handleActionClick = useCallback( async( action, version ) => {
-		switch ( action ) {
-			case 'delete':
-				closeAllModals();
-				setIsDeleteModalOpen( { version } );
-				break;
-			case 'export':
-				break;
-			case 'copy': {
-				const ok = await copyToClipboard( version.content ?? '' );
-				if ( ok ) {
-					createNotice(
-						'success',
-						__( 'Version copied to clipboard.', 'pattern-wrangler' ),
-						{ type: 'snackbar', isDismissible: true }
-					);
-				} else {
-					createNotice(
-						'error',
-						__( 'Could not copy to clipboard.', 'pattern-wrangler' ),
-						{ type: 'snackbar', isDismissible: true }
-					);
+	const handleActionClick = useCallback(
+		async( action, version ) => {
+			switch ( action ) {
+				case 'delete':
+					closeAllModals();
+					setIsDeleteModalOpen( { version } );
+					break;
+				case 'export': {
+					try {
+						const syncStatus =
+							version.wp_pattern_sync_status === 'unsynced' ? 'unsynced' : '';
+						const fileContent = JSON.stringify(
+							{
+								__file: 'wp_block',
+								title: version.title,
+								content: version.content ?? '',
+								syncStatus,
+							},
+							null,
+							2
+						);
+						const fileBase = getVersionExportFileBase(
+							version.title,
+							version.id
+						);
+						downloadBlob( `${ fileBase }.json`, fileContent, 'application/json' );
+						createNotice(
+							'success',
+							__( 'Version exported.', 'pattern-wrangler' ),
+							{ type: 'snackbar', isDismissible: true }
+						);
+					} catch ( err ) {
+						createNotice(
+							'error',
+							__( 'Could not export version.', 'pattern-wrangler' ),
+							{ type: 'snackbar', isDismissible: true }
+						);
+					}
+					break;
 				}
-				break;
+				case 'copy': {
+					const ok = await copyToClipboard( version.content ?? '' );
+					if ( ok ) {
+						createNotice(
+							'success',
+							__( 'Version copied to clipboard.', 'pattern-wrangler' ),
+							{ type: 'snackbar', isDismissible: true }
+						);
+					} else {
+						createNotice(
+							'error',
+							__( 'Could not copy to clipboard.', 'pattern-wrangler' ),
+							{ type: 'snackbar', isDismissible: true }
+						);
+					}
+					break;
+				}
+				case 'restore':
+					break;
 			}
-			case 'restore':
-				break;
-		}
-	}, [ closeAllModals, createNotice ] );
+		},
+		[ closeAllModals, createNotice ]
+	);
 
 	return (
 		<>

--- a/src/js/blocks/plugins/pattern-versions.js
+++ b/src/js/blocks/plugins/pattern-versions.js
@@ -5,6 +5,7 @@ import { PluginSidebar } from '@wordpress/editor';
 import { Button, Spinner, PanelBody, BaseControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
+import { copyToClipboard } from '../../utils/pattern-code-helpers';
 import PatternVersionCreateModal from './components/PatternVersionCreateModal';
 import PatternVersionCards from './components/PatternVersionCards';
 import PatternPreviewVersionModal from './components/PatternPreviewVersionModal';
@@ -99,7 +100,7 @@ const PatternVersionsSidebar = () => {
 		fetchVersions();
 	}, [ fetchVersions ] );
 
-	const handleActionClick = useCallback( ( action, version ) => {
+	const handleActionClick = useCallback( async( action, version ) => {
 		switch ( action ) {
 			case 'delete':
 				closeAllModals();
@@ -107,12 +108,27 @@ const PatternVersionsSidebar = () => {
 				break;
 			case 'export':
 				break;
-			case 'copy':
+			case 'copy': {
+				const ok = await copyToClipboard( version.content ?? '' );
+				if ( ok ) {
+					createNotice(
+						'success',
+						__( 'Version copied to clipboard.', 'pattern-wrangler' ),
+						{ type: 'snackbar', isDismissible: true }
+					);
+				} else {
+					createNotice(
+						'error',
+						__( 'Could not copy to clipboard.', 'pattern-wrangler' ),
+						{ type: 'snackbar', isDismissible: true }
+					);
+				}
 				break;
+			}
 			case 'restore':
 				break;
 		}
-	}, [] );
+	}, [ closeAllModals, createNotice ] );
 
 	return (
 		<>

--- a/src/js/blocks/plugins/pattern-versions.js
+++ b/src/js/blocks/plugins/pattern-versions.js
@@ -2,16 +2,12 @@ import { useState, useEffect, useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 import { PluginSidebar } from '@wordpress/editor';
-import {
-	Button,
-	Spinner,
-	PanelBody,
-	BaseControl,
-} from '@wordpress/components';
+import { Button, Spinner, PanelBody, BaseControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 import PatternVersionCreateModal from './components/PatternVersionCreateModal';
 import PatternVersionCards from './components/PatternVersionCards';
+import PatternPreviewVersionModal from './components/PatternPreviewVersionModal';
 
 const PatternWranglerIcon = (
 	<svg
@@ -67,6 +63,7 @@ const PatternVersionsSidebar = () => {
 	const [ versions, setVersions ] = useState( [] );
 	const [ loadingList, setLoadingList ] = useState( false );
 	const [ createVersionModalOpen, setCreateVersionModalOpen ] = useState( false );
+	const [ previewVersionModalOpen, setPreviewVersionModalOpen ] = useState( null );
 
 	const fetchVersions = useCallback( async() => {
 		if ( ! postId ) {
@@ -129,7 +126,12 @@ const PatternVersionsSidebar = () => {
 					<div className="dlx-pw-admin-row">
 						{ loadingList && <Spinner /> }
 						{ ! loadingList && versions.length > 0 && (
-							<PatternVersionCards versions={ versions } />
+							<PatternVersionCards
+								versions={ versions }
+								onPreviewClick={ ( version ) => {
+									setPreviewVersionModalOpen( { version } );
+								} }
+							/>
 						) }
 						{ ! loadingList && postId && versions.length === 0 && (
 							<p className="description">
@@ -158,6 +160,12 @@ const PatternVersionsSidebar = () => {
 						);
 						fetchVersions();
 					} }
+				/>
+			) }
+			{ previewVersionModalOpen && (
+				<PatternPreviewVersionModal
+					version={ previewVersionModalOpen.version }
+					onRequestClose={ () => setPreviewVersionModalOpen( false ) }
 				/>
 			) }
 		</>

--- a/src/js/blocks/plugins/pattern-versions.js
+++ b/src/js/blocks/plugins/pattern-versions.js
@@ -9,6 +9,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { downloadBlob } from '@wordpress/blob';
 import { copyToClipboard } from '../../utils/pattern-code-helpers';
 import PatternVersionCreateModal from './components/PatternVersionCreateModal';
+import PatternVersionCloneToPatternModal from './components/PatternVersionCloneToPatternModal';
 import PatternVersionCards from './components/PatternVersionCards';
 import PatternPreviewVersionModal from './components/PatternPreviewVersionModal';
 import VersionDeleteModal from './components/VersionDeleteModal/index';
@@ -97,6 +98,7 @@ const PatternVersionsSidebar = () => {
 	const [ previewVersionModalOpen, setPreviewVersionModalOpen ] = useState( null );
 	const [ isDeleteModalOpen, setIsDeleteModalOpen ] = useState( false );
 	const [ isRestoreModalOpen, setIsRestoreModalOpen ] = useState( false );
+	const [ cloneFromVersion, setCloneFromVersion ] = useState( null );
 
 	const fetchVersions = useCallback( async() => {
 		if ( ! postId ) {
@@ -124,6 +126,7 @@ const PatternVersionsSidebar = () => {
 	const closeAllModals = useCallback( () => {
 		setCreateVersionModalOpen( false );
 		setPreviewVersionModalOpen( null );
+		setCloneFromVersion( null );
 	}, [] );
 
 	useEffect( () => {
@@ -190,6 +193,10 @@ const PatternVersionsSidebar = () => {
 				case 'restore':
 					closeAllModals();
 					setIsRestoreModalOpen( { version } );
+					break;
+				case 'clone':
+					closeAllModals();
+					setCloneFromVersion( { version } );
 					break;
 			}
 		},
@@ -285,6 +292,14 @@ const PatternVersionsSidebar = () => {
 					version={ previewVersionModalOpen.version }
 					onRequestClose={ () => setPreviewVersionModalOpen( false ) }
 					onActionClick={ handleActionClick }
+				/>
+			) }
+			{ cloneFromVersion && (
+				<PatternVersionCloneToPatternModal
+					key={ cloneFromVersion.version.id }
+					version={ cloneFromVersion.version }
+					title={ __( 'Clone version to new pattern', 'pattern-wrangler' ) }
+					onRequestClose={ () => setCloneFromVersion( null ) }
 				/>
 			) }
 			{ isDeleteModalOpen && (

--- a/src/js/blocks/plugins/pattern-versions.js
+++ b/src/js/blocks/plugins/pattern-versions.js
@@ -131,6 +131,9 @@ const PatternVersionsSidebar = () => {
 								onPreviewClick={ ( version ) => {
 									setPreviewVersionModalOpen( { version } );
 								} }
+								onActionClick={ ( action, version ) => {
+									console.log( 'action', action, version );
+								} }
 							/>
 						) }
 						{ ! loadingList && postId && versions.length === 0 && (
@@ -166,6 +169,9 @@ const PatternVersionsSidebar = () => {
 				<PatternPreviewVersionModal
 					version={ previewVersionModalOpen.version }
 					onRequestClose={ () => setPreviewVersionModalOpen( false ) }
+					onActionClick={ ( action, version ) => {
+						console.log( 'action', action, version );
+					} }
 				/>
 			) }
 		</>

--- a/src/js/blocks/plugins/pattern-versions.js
+++ b/src/js/blocks/plugins/pattern-versions.js
@@ -4,21 +4,7 @@ import { registerPlugin } from '@wordpress/plugins';
 import { PluginSidebar } from '@wordpress/editor';
 import { parse } from '@wordpress/blocks';
 import { BlockPreview } from '@wordpress/block-editor';
-import {
-	Button,
-	Spinner,
-	PanelBody,
-	Card,
-	CardMedia,
-	CardBody,
-	CardHeader,
-	CardFooter,
-	CardDivider,
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalText as Text,
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalHeading as Heading,
-} from '@wordpress/components';
+import { Button, Spinner, PanelBody, BaseControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 import PatternVersionCreateModal from '../../react/views/patterns/components/PatternVersionCreateModal';
@@ -64,10 +50,11 @@ const PatternWranglerIcon = (
  * @return {JSX.Element} Markup.
  */
 const PatternVersionsSidebar = () => {
-	const { postId } = useSelect( ( selectStore ) => {
+	const { postId, hasUnsavedChanges } = useSelect( ( selectStore ) => {
 		const editor = selectStore( 'core/editor' );
 		return {
 			postId: editor.getCurrentPostId(),
+			hasUnsavedChanges: editor.isEditedPostDirty(),
 		};
 	}, [] );
 
@@ -108,22 +95,32 @@ const PatternVersionsSidebar = () => {
 		<>
 			<PluginSidebar
 				name="dlx-pattern-wrangler-versions"
-				title={ __( 'Pattern versions', 'pattern-wrangler' ) }
+				title={ __( 'Pattern Wrangler', 'pattern-wrangler' ) }
 				className="dlx-pw-preview-sidebar"
 				icon={ PatternWranglerIcon }
 			>
-				<PanelBody
-					title={ __( 'Pattern versions', 'pattern-wrangler' ) }
-					icon={ PatternWranglerIcon }
-				>
+				<PanelBody title={ __( 'Pattern versions', 'pattern-wrangler' ) }>
 					<div className="dlx-pw-admin-row">
-						<Button
-							variant="secondary"
-							onClick={ () => setCreateVersionModalOpen( true ) }
-							disabled={ ! postId }
+						<BaseControl
+							id="dlx-pw-versions-save-version"
+							label={ __( 'Save Version', 'pattern-wrangler' ) }
+							help={
+								hasUnsavedChanges
+									? __(
+										'Save or update the pattern in the editor before creating a version.',
+										'pattern-wrangler'
+									  )
+									: undefined
+							}
 						>
-							{ __( 'Save Version', 'pattern-wrangler' ) }
-						</Button>
+							<Button
+								variant="secondary"
+								onClick={ () => setCreateVersionModalOpen( true ) }
+								disabled={ ! postId || hasUnsavedChanges }
+							>
+								{ __( 'Save New Version', 'pattern-wrangler' ) }
+							</Button>
+						</BaseControl>
 					</div>
 					<div className="dlx-pw-admin-row">
 						{ loadingList && <Spinner /> }

--- a/src/js/blocks/plugins/pattern-versions.js
+++ b/src/js/blocks/plugins/pattern-versions.js
@@ -192,21 +192,8 @@ const PatternVersionsSidebar = () => {
 												>
 													{ __( 'Delete', 'pattern-wrangler' ) }
 												</Button>
-												{ ' | ' }
-												<Button
-													variant="link"
-													label={ __( 'Export', 'pattern-wrangler' ) }
-												>
-													{ __( 'Export', 'pattern-wrangler' ) }
-												</Button>
-												{ ' | ' }
-												<Button
-													variant="link"
-													label={ __( 'Copy', 'pattern-wrangler' ) }
-												>
-													{ __( 'Copy', 'pattern-wrangler' ) }
-												</Button>
 											</div>
+											<div className="dlx-pw-version-item-date">{ v.date }</div>
 										</div>
 									</>
 								) ) }

--- a/src/js/react/views/main/main.js
+++ b/src/js/react/views/main/main.js
@@ -48,6 +48,7 @@ const Main = () => {
 				showMenusUI: data.showMenusUI,
 				makePatternsExportable: data.makePatternsExportable,
 				disablePatternRevisions: data.disablePatternRevisions,
+				enableVersionsModule: data.enableVersionsModule ?? false,
 				patternWranglerMenuLocation: data.patternWranglerMenuLocation,
 				patternsDefaultView:
 					dlxPatternWranglerAdmin.patternsDefaultView || 'all',
@@ -85,10 +86,7 @@ const Main = () => {
 					control={ control }
 					render={ ( { field: { onChange, value } } ) => (
 						<ToggleControl
-							label={ __(
-								'Disable Pattern Revisions',
-								'pattern-wrangler'
-							) }
+							label={ __( 'Disable Pattern Revisions', 'pattern-wrangler' ) }
 							checked={ networkLocksRevisions ? true : value }
 							disabled={ networkLocksRevisions }
 							help={ __(
@@ -1100,6 +1098,35 @@ const Main = () => {
 														{ __( 'In Appearance', 'pattern-wrangler' ) }
 													</option>
 												</SelectControl>
+											) }
+										/>
+									</div>
+								</td>
+							</tr>
+							<tr>
+								<th scope="row">
+									{ __( 'Pattern Versions', 'pattern-wrangler' ) }
+								</th>
+								<td>
+									<div className="dlx-admin__row">
+										<Controller
+											name="enableVersionsModule"
+											control={ control }
+											render={ ( { field: { onChange, value } } ) => (
+												<ToggleControl
+													label={ __(
+														'Enable pattern versions module',
+														'pattern-wrangler'
+													) }
+													checked={ value }
+													onChange={ ( boolValue ) => {
+														onChange( boolValue );
+													} }
+													help={ __(
+														'Adds checkpoints (snapshots) in the block editor sidebar and optional auto-snapshots on save.',
+														'pattern-wrangler'
+													) }
+												/>
 											) }
 										/>
 									</div>

--- a/src/js/react/views/patterns/components/PatternCreateModal/index.js
+++ b/src/js/react/views/patterns/components/PatternCreateModal/index.js
@@ -62,26 +62,34 @@ const PatternCreateModal = ( props ) => {
 	const categories = ( props.categories || [] ).map( ( category ) => {
 		return category.label || category.name;
 	} );
-	const localPatternCategories = ( props.patternCategories || [] ).map( ( category ) => {
-		const categorySlug = cleanForSlug( category.label || category.name || category );
-		// Find category label from slug.
-		const categoryObject = originalCategories.find( ( c ) => cleanForSlug( c.label || c.name ) === categorySlug );
-		return escapeHTML( categoryObject?.label ?? ( category.label || category.name || category ) );
-	} );
+	const localPatternCategories = ( props.patternCategories || [] ).map(
+		( category ) => {
+			const categorySlug = cleanForSlug(
+				category.label || category.name || category
+			);
+			// Find category label from slug.
+			const categoryObject = originalCategories.find(
+				( c ) => cleanForSlug( c.label || c.name ) === categorySlug
+			);
+			return escapeHTML(
+				categoryObject?.label ?? ( category.label || category.name || category )
+			);
+		}
+	);
 	const [ copyPatternId ] = useState( props.copyItem?.id || 0 );
 	const [ syncedDefaultStatus ] = useState( props.syncedDefaultStatus || 'synced' );
 	const [ syncedDisabled ] = useState( props.syncedDisabled || false );
 	const [ isSaving, setIsSaving ] = useState( false );
 	const [ isEditMode ] = useState( props.isEditMode || false );
-	const [ disableRegisteredPattern, setDisableRegisteredPattern ] = useState( getEditPatternConfig().disableRegisteredPattern ?? false );
-	const [ editPatternAferCreating, setEditPatternAferCreating ] = useState( getEditPatternConfig().editPatternAferCreating ?? true );
+	const [ disableRegisteredPattern, setDisableRegisteredPattern ] = useState(
+		getEditPatternConfig().disableRegisteredPattern ?? false
+	);
+	const [ editPatternAferCreating, setEditPatternAferCreating ] = useState(
+		getEditPatternConfig().editPatternAferCreating ?? true
+	);
 	const [ showExpandedSuggestions, setShowExpandedSuggestions ] = useState( true );
 
-	const {
-		control,
-		handleSubmit,
-		setError,
-	} = useForm( {
+	const { control, handleSubmit, setError } = useForm( {
 		defaultValues: {
 			patternId: props.patternId || 0,
 			patternNonce: props.patternNonce || '',
@@ -105,12 +113,10 @@ const PatternCreateModal = ( props ) => {
 	 * @return {string|null} The label id.
 	 */
 	const getIdByValue = ( labelValue ) => {
-		const label = originalCategories.find(
-			( findLabel ) => {
-				const findNewLabel = findLabel.label || findLabel.name;
-				return findNewLabel.toLowerCase() === labelValue.toLowerCase();
-			}
-		);
+		const label = originalCategories.find( ( findLabel ) => {
+			const findNewLabel = findLabel.label || findLabel.name;
+			return findNewLabel.toLowerCase() === labelValue.toLowerCase();
+		} );
 		return label ? label.id : 0;
 	};
 
@@ -140,7 +146,6 @@ const PatternCreateModal = ( props ) => {
 				patternSyncStatus: formData.patternSyncStatus,
 				patternCopyId: formData.patternCopyId,
 				disableRegisteredPattern,
-
 			},
 		} );
 		if ( response?.error ) {
@@ -149,10 +154,13 @@ const PatternCreateModal = ( props ) => {
 			const patternId = response.patternId;
 			// Save edit pattern config to local storage.
 			if ( ! isEditMode ) {
-				localStorage.setItem( 'dlx-pw-edit-pattern-config', JSON.stringify( {
-					editPatternAferCreating,
-					disableRegisteredPattern,
-				} ) );
+				localStorage.setItem(
+					'dlx-pw-edit-pattern-config',
+					JSON.stringify( {
+						editPatternAferCreating,
+						disableRegisteredPattern,
+					} )
+				);
 			}
 			if ( ! isEditMode && editPatternAferCreating ) {
 				const redirectUrl = encodeURIComponent( window.location.href );
@@ -245,10 +253,16 @@ const PatternCreateModal = ( props ) => {
 													setShowExpandedSuggestions( true );
 												}
 											} }
-											__experimentalExpandOnFocus={ ( field.value.length === 0 && showExpandedSuggestions ) || showExpandedSuggestions }
+											__experimentalExpandOnFocus={
+												( field.value.length === 0 && showExpandedSuggestions ) ||
+												showExpandedSuggestions
+											}
 										/>
 										<p className="description">
-											{ __( 'Separate with commas or press the Enter key.', 'pattern-wrangler' ) }
+											{ __(
+												'Separate with commas or press the Enter key.',
+												'pattern-wrangler'
+											) }
 										</p>
 									</>
 								) }
@@ -288,38 +302,34 @@ const PatternCreateModal = ( props ) => {
 								) }
 							/>
 						</div>
-						{
-							copyPatternId !== 0 && (
-								<div className="dlx-pw-modal-admin-row">
-									<ToggleControl
-										label={ __( 'Disable Registered Pattern', 'pattern-wrangler' ) }
-										checked={ disableRegisteredPattern }
-										onChange={ ( value ) => setDisableRegisteredPattern( value ) }
-										help={ __(
-											'Disable the registered pattern when you copy it to local.',
-											'pattern-wrangler'
-										) }
-										disabled={ isSaving }
-									/>
-								</div>
-							)
-						}
-						{
-							! isEditMode && (
-								<div className="dlx-pw-modal-admin-row">
-									<ToggleControl
-										label={ __( 'Edit Pattern After Creating', 'pattern-wrangler' ) }
-										checked={ editPatternAferCreating }
-										onChange={ ( value ) => setEditPatternAferCreating( value ) }
-										help={ __(
-											'Edit the pattern after creating it. Uncheck to stay on this screen.',
-											'pattern-wrangler'
-										) }
-										disabled={ isSaving }
-									/>
-								</div>
-							)
-						}
+						{ copyPatternId !== 0 && (
+							<div className="dlx-pw-modal-admin-row">
+								<ToggleControl
+									label={ __( 'Disable Registered Pattern', 'pattern-wrangler' ) }
+									checked={ disableRegisteredPattern }
+									onChange={ ( value ) => setDisableRegisteredPattern( value ) }
+									help={ __(
+										'Disable the registered pattern when you copy it to local.',
+										'pattern-wrangler'
+									) }
+									disabled={ isSaving }
+								/>
+							</div>
+						) }
+						{ ! isEditMode && (
+							<div className="dlx-pw-modal-admin-row">
+								<ToggleControl
+									label={ __( 'Edit Pattern After Creating', 'pattern-wrangler' ) }
+									checked={ editPatternAferCreating }
+									onChange={ ( value ) => setEditPatternAferCreating( value ) }
+									help={ __(
+										'Edit the pattern after creating it. Uncheck to stay on this screen.',
+										'pattern-wrangler'
+									) }
+									disabled={ isSaving }
+								/>
+							</div>
+						) }
 						<div className="dlx-pw-modal-admin-row dlx-pw-modal-admin-row-buttons">
 							<Button variant="primary" type="submit" disabled={ isSaving }>
 								{ getButtonText() }

--- a/src/js/react/views/patterns/components/PatternVersionCreateModal/index.js
+++ b/src/js/react/views/patterns/components/PatternVersionCreateModal/index.js
@@ -1,0 +1,190 @@
+// eslint-disable-next-line no-unused-vars
+import React, { useState } from 'react';
+import {
+	TextControl,
+	Modal,
+	Button,
+	TextareaControl,
+} from '@wordpress/components';
+import apiFetch from '@wordpress/api-fetch';
+import { AlertTriangle } from 'lucide-react';
+
+import { __ } from '@wordpress/i18n';
+import { useForm, Controller, useWatch, useFormState } from 'react-hook-form';
+
+// Local imports.
+import Notice from '../../../../components/Notice';
+
+/**
+ * Pattern Create Modal.
+ *
+ * @param {Object}   props                     The props.
+ * @param {string}   props.title               The title of the modal.
+ * @param {string}   props.patternId           The id of the pattern.
+ * @param {string}   props.patternNonce        The nonce of the pattern.
+ * @param {string}   props.patternTitle        The title of the pattern.
+ * @param {Array}    props.patternCategories   The categories of the pattern in label arrays.
+ * @param {string}   props.patternSyncStatus   The sync status of the pattern.
+ * @param {string}   props.patternCopyId       The id of the pattern to copy.
+ * @param {Object}   props.categories          The categories of all the patterns..
+ * @param {Function} props.onRequestClose      The function to call when the modal is closed.
+ * @param {string}   props.syncedDefaultStatus The default sync status of the pattern. Values are 'synced' or 'unsynced'.
+ * @param {boolean}  props.syncedDisabled      Whether the synced status is disabled.
+ * @param {Function} props.onEdit              The function to call when the pattern is edited.
+ * @return {Object} The rendered component.
+ */
+const PatternVersionCreateModal = ( props ) => {
+	const [ isSaving, setIsSaving ] = useState( false );
+	const [ isEditMode ] = useState( props.isEditMode || false );
+
+	const { control, handleSubmit, setError } = useForm( {
+		defaultValues: {
+			versionTitle: props.versionTitle ?? '',
+			versionDescription: props.versionDescription ?? '',
+		},
+	} );
+	// eslint-disable-next-line no-unused-vars
+	const formValues = useWatch( { control } );
+	const { errors } = useFormState( {
+		control,
+	} );
+
+	const onSubmit = async( formData ) => {
+		setIsSaving( true );
+
+		const response = await apiFetch( {
+			path: '/dlxplugins/pattern-wrangler/v1/versions',
+			method: 'POST',
+			data: {
+				parentId: props.patternId,
+				title: formData.versionTitle,
+				description: formData.versionDescription,
+				nonce: props.patternNonce,
+			},
+		} );
+		if ( response?.error ) {
+			setError( 'versionTitle', { message: response.error } );
+		} else {
+			props.onCreate( response );
+		}
+		setIsSaving( false );
+	};
+
+	/**
+	 * Get the button text.
+	 *
+	 * @return {string} The button text.
+	 */
+	const getButtonText = () => {
+		let buttonText = __( 'Create Version', 'pattern-wrangler' );
+		if ( isEditMode ) {
+			buttonText = __( 'Save Version', 'pattern-wrangler' );
+		}
+		if ( isSaving ) {
+			buttonText = __( 'Saving Version…', 'pattern-wrangler' );
+		}
+		return buttonText;
+	};
+
+	return (
+		<>
+			<Modal
+				title={ props.title || __( 'Create New Version', 'pattern-wrangler' ) }
+				onRequestClose={ props.onRequestClose }
+				focusOnMount="firstContentElement"
+			>
+				<div className="dlx-pw-modal-content">
+					<form onSubmit={ handleSubmit( onSubmit ) }>
+						<div className="dlx-pw-modal-admin-row">
+							<Controller
+								control={ control }
+								name="versionTitle"
+								rules={ {
+									required: __(
+										'Version title is required.',
+										'pattern-wrangler'
+									),
+								} }
+								render={ ( { field } ) => (
+									<TextControl
+										label={ __( 'Version Title', 'pattern-wrangler' ) }
+										help={ __(
+											'Enter the title of the version.',
+											'pattern-wrangler'
+										) }
+										value={ field.value }
+										onChange={ ( value ) => field.onChange( value ) }
+										disabled={ isSaving }
+									/>
+								) }
+							/>
+						</div>
+						<div className="dlx-pw-modal-admin-row">
+							<Controller
+								control={ control }
+								name="versionDescription"
+								rules={ {
+									required: __(
+										'Version description is required.',
+										'pattern-wrangler'
+									),
+								} }
+								render={ ( { field } ) => (
+									<TextareaControl
+										label={ __( 'Version Description', 'pattern-wrangler' ) }
+										help={ __(
+											'Enter the description of the version.',
+											'pattern-wrangler'
+										) }
+										value={ field.value }
+										onChange={ ( value ) => field.onChange( value ) }
+										disabled={ isSaving }
+										rows={ 3 }
+										placeholder={ __(
+											'Enter the description of the version.',
+											'pattern-wrangler'
+										) }
+									/>
+								) }
+							/>
+						</div>
+						<div className="dlx-pw-modal-admin-row dlx-pw-modal-admin-row-buttons">
+							<Button variant="primary" type="submit" disabled={ isSaving }>
+								{ getButtonText() }
+							</Button>
+							<Button
+								variant="secondary"
+								onClick={ props.onRequestClose }
+								disabled={ isSaving }
+							>
+								{ __( 'Cancel', 'pattern-wrangler' ) }
+							</Button>
+						</div>
+						{ errors?.versionTitle && (
+							<Notice
+								className="dlx-pw-admin-notice"
+								status="error"
+								inline={ true }
+								icon={ () => <AlertTriangle /> }
+							>
+								{ errors.versionTitle.message }
+							</Notice>
+						) }
+						{ errors?.versionDescription && (
+							<Notice
+								className="dlx-pw-admin-notice"
+								status="error"
+								inline={ true }
+								icon={ () => <AlertTriangle /> }
+							>
+								{ errors.versionDescription.message }
+							</Notice>
+						) }
+					</form>
+				</div>
+			</Modal>
+		</>
+	);
+};
+
+export default PatternVersionCreateModal;

--- a/src/js/react/views/patterns/components/PatternsGrid.js
+++ b/src/js/react/views/patterns/components/PatternsGrid.js
@@ -858,9 +858,20 @@ const Interface = ( props ) => {
 		if ( 'undefined' !== searchField && '' !== searchField ) {
 			patternsCopy = patternsCopy.filter( ( pattern ) => {
 				const patternLabel = pattern.label || pattern.title;
-				return patternLabel
+				const patternLabelMatches = patternLabel
 					.toLowerCase()
 					.includes( ( newView.search || searchField ).toLowerCase() );
+				const patternCategoriesMatches = pattern.categorySlugs.some(
+					( category ) => {
+						const categoryName =
+							category.name || category.label || category.toString();
+						return categoryName
+							.toLowerCase()
+							.includes( ( newView.search || searchField ).toLowerCase() );
+					}
+				);
+				const patternMatches = [ patternLabelMatches, patternCategoriesMatches ];
+				return patternMatches.some( ( match ) => match );
 			} );
 		}
 

--- a/src/js/react/views/patterns/components/PatternsGrid.js
+++ b/src/js/react/views/patterns/components/PatternsGrid.js
@@ -602,17 +602,21 @@ const Interface = ( props ) => {
 							>
 								{ _x( 'Export', 'Export Pattern', 'pattern-wrangler' ) }
 							</Button>
-							{ ' | ' }
-							<Button
-								variant="link"
-								onClick={ ( e ) => {
-									e.preventDefault();
-									e.stopPropagation();
-									setIsPauseModalOpen( { items: [ item ] } );
-								} }
-							>
-								{ _x( 'Disable', 'Disable Pattern', 'pattern-wrangler' ) }
-							</Button>
+							{ ! item.isDisabled && (
+								<>
+									{ ' | ' }
+									<Button
+										variant="link"
+										onClick={ ( e ) => {
+											e.preventDefault();
+											e.stopPropagation();
+											setIsPauseModalOpen( { items: [ item ] } );
+										} }
+									>
+										{ _x( 'Disable', 'Disable Pattern', 'pattern-wrangler' ) }
+									</Button>
+								</>
+							) }
 						</>
 					) }
 				</div>

--- a/src/js/react/views/patterns/components/PatternsGrid.js
+++ b/src/js/react/views/patterns/components/PatternsGrid.js
@@ -1935,6 +1935,15 @@ const Interface = ( props ) => {
 											dispatch( patternsStore ).addPattern( getPatternResponse );
 										}
 									}
+									setSnackbar( {
+										isVisible: true,
+										message: __( 'Pattern imported', 'pattern-wrangler' ),
+										title: __( 'Pattern Imported', 'pattern-wrangler' ),
+										type: 'success',
+										onClose: () => {
+											setSnackbar( { isVisible: false } );
+										},
+									} );
 								} catch ( err ) {}
 								// Reset so selecting the same file again triggers onChange.
 								event.target.value = '';

--- a/src/scss/patterns-editor.scss
+++ b/src/scss/patterns-editor.scss
@@ -199,6 +199,10 @@
 }
 
 .dlx-pw-version-item-header {
+	display: grid;
+	grid-template-columns: 1fr auto;
+	align-items: center;
+	gap: 8px;
 	margin: 0;
 	padding: 0;
 }
@@ -207,4 +211,8 @@
 	border: 1px solid #e0e0e0;
 	border-radius: 4px;
 	padding: 4px;
+}
+
+.dlx-pw-version-item-popover-content .components-dropdown-menu__menu {
+	min-width: 75px;
 }

--- a/src/scss/patterns-editor.scss
+++ b/src/scss/patterns-editor.scss
@@ -213,6 +213,7 @@
 }
 
 .dlx-pw-version-item-media {
+	position: relative;
 	border: 1px solid #e0e0e0;
 	border-radius: 4px;
 	padding: 4px;
@@ -220,4 +221,13 @@
 
 .dlx-pw-version-item-popover-content .components-dropdown-menu__menu {
 	min-width: 75px;
+}
+
+.dlx-pw-version-item-preview-button {
+	position: absolute;
+	top: 0;
+	right: 0;
+	width: 100% !important;
+	height: 100% !important;
+	z-index: 100 !important;
 }

--- a/src/scss/patterns-editor.scss
+++ b/src/scss/patterns-editor.scss
@@ -217,6 +217,9 @@
 	border: 1px solid #e0e0e0;
 	border-radius: 4px;
 	padding: 4px;
+	overflow: hidden;
+	max-height: 175px;
+	aspect-ratio: 1 / 1;
 }
 
 .dlx-pw-version-item-popover-content .components-dropdown-menu__menu {

--- a/src/scss/patterns-editor.scss
+++ b/src/scss/patterns-editor.scss
@@ -2,6 +2,10 @@
 	margin-bottom: 16px;
 }
 
+.dlx-pw-admin-row {
+	margin-bottom: 16px;
+}
+
 .dlx-pw-modal-admin-row-buttons {
 	display: flex;
 	gap: 8px;
@@ -177,4 +181,30 @@
 			color: var(--dlx-pw-admin--color-notice--warning-alt);
 		}
 	}
+}
+
+.dlx-pw-versions-grid {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 16px;
+}
+
+.dlx-pw-version-item {
+	display: flex;
+	flex-direction: column;
+	border: 1px solid #e0e0e0;
+	border-radius: 4px;
+	padding: 16px;
+	gap: 8px;
+}
+
+.dlx-pw-version-item-header {
+	margin: 0;
+	padding: 0;
+}
+
+.dlx-pw-version-item-media {
+	border: 1px solid #e0e0e0;
+	border-radius: 4px;
+	padding: 4px;
 }

--- a/src/scss/patterns-editor.scss
+++ b/src/scss/patterns-editor.scss
@@ -207,6 +207,11 @@
 	padding: 0;
 }
 
+.dlx-pw-version-item-date {
+	font-size: 12px;
+	color: #666;
+}
+
 .dlx-pw-version-item-media {
 	border: 1px solid #e0e0e0;
 	border-radius: 4px;

--- a/src/scss/patterns-editor.scss
+++ b/src/scss/patterns-editor.scss
@@ -2,6 +2,24 @@
 	margin-bottom: 16px;
 }
 
+.dlx-pw-modal-admin-row {
+	.is-required label {
+		position: relative;
+	}
+
+	.is-required label:after {
+		position: absolute;
+		display: inline-block;
+		vertical-align: middle;
+		content: '*';
+		top: -3px;
+		color: #b53b07;
+		font-size: 1.4em;
+		line-height: 1.3;
+		margin-left: 8px;
+	}
+}
+
 .dlx-pw-admin-row {
 	margin-bottom: 16px;
 }

--- a/src/scss/patterns-editor.scss
+++ b/src/scss/patterns-editor.scss
@@ -1,0 +1,180 @@
+.dlx-pw-modal-admin-row {
+	margin-bottom: 16px;
+}
+
+.dlx-pw-modal-admin-row-buttons {
+	display: flex;
+	gap: 8px;
+	justify-content: flex-start;
+	flex-direction: row-reverse;
+	align-items: center;
+	padding-top: 16px;
+}
+
+
+
+:root {
+	--dlx-pw-admin--color-notice--info: #e3f3f7;
+	--dlx-pw-admin--color-notice--info-alt: #3a8dc4;
+	--dlx-pw-admin--color-notice--success: #eaf5ea;
+	--dlx-pw-admin--color-notice--success-alt: #49a939;
+	--dlx-pw-admin--color-notice--warning: #fef6e1;
+	--dlx-pw-admin--color-notice--warning-alt: #e8a931;
+	--dlx-pw-admin--color-notice--error: #f5e5e4;
+	--dlx-pw-admin--color-notice--error-alt: #bc2b2c;
+	--dlx-pw-admin--color-notice--rating: #ff00f7;
+	--dlx-pw-admin--color-notice--rating-alt: #b1b1b1;
+}
+
+/* Error Notices */
+.dlx-pw-admin__notice {
+	margin: 10px 0;
+
+	&.dlx-pw-admin__notice--has-icon {
+		.components-notice__content {
+			display: grid;
+			grid-template-columns: 32px 1fr 1px;
+			align-items: center;
+		}
+
+		&.dlx-pw-admin__notice-appearance--inline .components-notice__content {
+			display: flex;
+
+			.dlx-pw-admin__notice-icon {
+				margin-right: 8px;
+			}
+		}
+	}
+
+	.is-error,
+	.is-critical {
+		background-color: #A13844;
+		border-left-color: #A13844;
+		color: #FFF;
+	}
+
+	.dlx-pw-admin__notice-message {
+		font-size: 1.2em;
+		line-height: 1.4;
+		font-weight: 500;
+	}
+
+	&.dlx-pw-admin__notice-appearance--block .components-notice {
+		border-left: 4px solid transparent;
+		padding: 15px 20px;
+		padding-left: 15px;
+		margin-bottom: 15px;
+		margin-left: 0;
+		margin-right: 0;
+	}
+
+	&.dlx-pw-admin__notice-appearance--inline .components-notice {
+		padding-left: 0;
+		margin-left: 0;
+		margin-right: 0;
+	}
+
+	svg {
+		display: flex;
+		align-items: center;
+		width: 24px;
+		height: 24px;
+	}
+
+	&.dlx-pw-admin__notice-type--error:not(.dlx-pw-admin__notice-appearance--inline) {
+		background-color: var(--dlx-pw-admin--color-notice--error);
+
+		.components-notice {
+			border-left-color: var(--dlx-pw-admin--color-notice--error-alt);
+		}
+
+		svg {
+			color: var(--dlx-pw-admin--color-notice--error-alt);
+		}
+
+		svg path {
+			fill: var(--dlx-pw-admin--color-notice--error-alt);
+		}
+	}
+
+	&.dlx-pw-admin__notice-type--error.dlx-pw-admin__notice-appearance--inline {
+		.dlx-pw-admin__notice-message {
+			color: #FFF;
+			fill: #FFF;
+		}
+
+		svg {
+			width: 16px;
+			height: 16px;
+			margin-left: 15px;
+			margin-right: 8px;
+		}
+
+		.components-notice__content {
+			padding: 8px 15px 8px 0;
+		}
+	}
+
+	&.dlx-pw-admin__notice-type--success {
+		background-color: var(--dlx-pw-admin--color-notice--success);
+
+		.components-notice {
+			border-left-color: var(--dlx-pw-admin--color-notice--success-alt);
+		}
+
+		svg path {
+			fill: var(--dlx-pw-admin--color-notice--success-alt)
+		}
+	}
+
+	&.dlx-pw-admin__notice-type--rating {
+		background-color: var(--dlx-pw-admin--color-notice--rating-alt);
+
+		.components-notice {
+			border-left-color: var(--dlx-pw-admin--color-notice--rating);
+		}
+
+		svg path {
+			fill: var(--dlx-pw-admin--color-notice--rating) !important;
+			stroke: var(--dlx-pw-admin--color-notice--rating) !important;
+		}
+	}
+
+	&.dlx-pw-admin__notice-type--info {
+		background-color: var(--dlx-pw-admin--color-notice--info);
+
+		.components-notice {
+			border-left-color: var(--dlx-pw-admin--color-notice--info-alt);
+		}
+
+		.dlx-pw-admin__notice-icon {
+			svg:not(.lucide) path {
+				fill: var(--dlx-pw-admin--color-notice--info-alt);
+			}
+
+			svg.lucide {
+				color: var(--dlx-pw-admin--color-notice--info-alt);
+			}
+		}
+
+		svg:not(.lucide) path {
+			fill: var(--dlx-pw-admin--color-notice--info-alt);
+		}
+	}
+
+	&.dlx-pw-admin__notice-type--warning {
+		background-color: var(--dlx-pw-admin--color-notice--warning);
+
+		.components-notice {
+			border-left-color: var(--dlx-pw-admin--color-notice--warning-alt);
+		}
+
+		svg:not(.lucide) path {
+			fill: var(--dlx-pw-admin--color-notice--warning-alt);
+		}
+
+		svg.lucide {
+			color: var(--dlx-pw-admin--color-notice--warning-alt);
+		}
+	}
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,17 +19,11 @@ module.exports = ( env ) => {
 			devtool: 'production' === env.mode ? false : 'source-map',
 			entry: {
 				index: '/src/index.js',
-				'dlx-pw-preview': './src/js/blocks/plugins/pattern-preview.js',
+				'dlx-pw-preview': [ './src/js/blocks/plugins/pattern-preview.js' ],
 				'dlx-pw-fancybox': './src/js/fancybox/index.js',
-				'dlx-pw-patterns-view': [
-					'./src/js/react/views/patterns/index.js',
-				],
-				'dlx-pw-categories-view': [
-					'./src/js/react/views/categories/index.js',
-				],
-				'dlx-pw-hide-ui': [
-					'./src/js/helpers/hide-ui.js',
-				],
+				'dlx-pw-patterns-view': [ './src/js/react/views/patterns/index.js' ],
+				'dlx-pw-categories-view': [ './src/js/react/views/categories/index.js' ],
+				'dlx-pw-hide-ui': [ './src/js/helpers/hide-ui.js' ],
 			},
 			resolve: {
 				alias: {
@@ -50,6 +44,7 @@ module.exports = ( env ) => {
 				'dlx-pw-admin-css': './src/scss/admin.scss',
 				'dlx-pw-post-utilities': './src/js/utils/index.js',
 				'dlx-pw-admin-utils-css': './src/scss/admin-utils.scss',
+				'dlx-pw-patterns-editor': './src/scss/patterns-editor.scss',
 			},
 			resolve: {
 				alias: {


### PR DESCRIPTION
Implements a new Pattern Versions module, enabling users to manage snapshots (versions) of their block patterns directly within the block editor.

**Key Features:**
*   **Version Checkpoints:** Create and save multiple versions of a pattern at any point.
*   **Preview Versions:** View previous pattern versions in a dedicated modal.
*   **Restore Functionality:** Revert a pattern to any saved version, with an option to create a snapshot of the current state before restoring.
*   **Clone to New Pattern:** Duplicate a version to create an entirely new pattern, allowing for branching design iterations.
*   **Export & Copy:** Export version content to JSON or copy to clipboard for easy sharing or backup.
*   **Delete Versions:** Remove unwanted versions.
*   **Editor Integration:** A new sidebar in the block editor provides an interface to manage versions for the current pattern. The "Save New Version" button disables when there are unsaved changes or content is empty.
*   **Admin Control:** An option in the plugin settings allows administrators to enable or disable the entire versions module.

**Technical Enhancements:**
*   Introduces a `pw_versions` custom post type to store pattern snapshots, supporting title, editor, excerpt, and author.
*   Adds dedicated REST API endpoints for fetching, creating, deleting, and restoring pattern versions.
*   Integrates new React components for the editor sidebar and various modals (create, preview, restore, delete, clone).
*   Configures Prettier and updates ESLint rules for improved code consistency and quality.